### PR TITLE
Adding the work to allow VERSION_PREFIX to be set on get version calls

### DIFF
--- a/cmd/pulumictl/get/version/cli.go
+++ b/cmd/pulumictl/get/version/cli.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	language string
+	versionPrefix string
 	omitCommitHash bool
 )
 
@@ -44,8 +45,10 @@ func Command() *cobra.Command {
 			}
 
 			language = viper.GetString("language")
+			versionPrefix = viper.GetString("version-prefix")
 
-			versions, err := gitversion.GetLanguageVersions(repo, plumbing.Revision(commitish), omitCommitHash)
+			versions, err := gitversion.GetLanguageVersions(repo, plumbing.Revision(commitish),
+				omitCommitHash, versionPrefix)
 			if err != nil {
 				return fmt.Errorf("error calculating version: %w", err)
 			}
@@ -70,10 +73,15 @@ func Command() *cobra.Command {
 
 	command.Flags().StringP("repo", "r", "", "path to repository, defaults to current working directory")
 	command.Flags().StringVarP(&language, "language", "p", "", "the platform for which the version should be output.")
+	command.Flags().StringVar(&versionPrefix, "version-prefix", "", "the version prefix (e.g. 3.0.0). Must be valid semver.")
 	command.Flags().BoolVarP(&omitCommitHash, "omit-commit-hash", "o", false, "whether to include or omit the commit hash in the version")
+
 	viper.SetDefault("language", "generic")
 	viper.BindEnv("language", "PULUMI_LANGUAGE")
 	viper.BindPFlag("language", command.Flags().Lookup("language"))
+
+	viper.BindEnv("version-prefix", "VERSION_PREFIX")
+	viper.BindPFlag("version-prefix", command.Flags().Lookup("version-prefix"))
 
 	return command
 }

--- a/cmd/pulumictl/version/cli.go
+++ b/cmd/pulumictl/version/cli.go
@@ -25,7 +25,7 @@ func Command() *cobra.Command {
 				if err != nil {
 					return fmt.Errorf("error obtaining working directory: %w", err)
 				}
-				version, err := gitversion.GetLanguageVersions(workingDir, plumbing.Revision(commitish), true)
+				version, err := gitversion.GetLanguageVersions(workingDir, plumbing.Revision(commitish), true, "")
 				if err != nil {
 					return fmt.Errorf("error calculating version: %w", err)
 				}


### PR DESCRIPTION
Fixes: #27

```
./main get version --language generic
0.0.17-alpha.1614786832+1e03d208.dirty
```

```
VERSION_PREFIX=1.0.0 ./main get version --language generic
1.0.0-alpha.1614786832+1e03d208.dirty
```
