### PR TITLE
Ignore tags with beta and rc in them as part of calculating version

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
+github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1 h1:VkoXIwSboBpnk99O/KFauAEILuNHv5DVFKZMBN/gUgw=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -173,6 +175,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af h1:gu+uRPtBe88sK
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/ryboe/q v1.0.13 h1:A7lqkemc1+OmnhjH5wSrrJZZdVwEiLisOoP9QAEEAQk=
+github.com/ryboe/q v1.0.13/go.mod h1:ISWUxiBpZfTx3deLPD3TWaP4R8ZUw98Ki1IUVCo2Mjc=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=

--- a/pkg/gitversion/gitversion.go
+++ b/pkg/gitversion/gitversion.go
@@ -158,7 +158,6 @@ func versionAtCommitForRepo(workingDirPath string, commitish plumbing.Revision, 
 	if err != nil {
 		return nil, fmt.Errorf("error parsing base versionComponents %q: %w", baseVersion, err)
 	}
-
 	if !isExact {
 		if version.Major == 0 {
 			version.Patch += 1
@@ -252,6 +251,12 @@ func isExactTag(repo *git.Repository, hash plumbing.Hash) (bool, *plumbing.Refer
 
 	var exactTag *plumbing.Reference = nil
 	if err := tags.ForEach(func(ref *plumbing.Reference) error {
+		// we want to ignore the beta and rc tags - they ar ethe next major version so we
+		// don't want to use these in our calculations of the current release variant
+		if strings.Contains(ref.Name().String(), "beta") ||
+			strings.Contains(ref.Name().String(), "rc") {
+			return nil
+		}
 		if ref.Hash() == hash {
 			exactTag = ref
 			return storer.ErrStop

--- a/pkg/gitversion/gitversion_test.go
+++ b/pkg/gitversion/gitversion_test.go
@@ -91,6 +91,17 @@ func TestIsExactTag(t *testing.T) {
 		require.NotNil(t, exact)
 		require.True(t, isExact)
 	})
+
+	t.Run("Skip the beta tag", func(t *testing.T) {
+		exactRef, err := repo.Tag("v2.0.0-beta.1")
+		require.NoError(t, err)
+		require.NotNil(t, exactRef)
+
+		isExact, exact, err := isExactTag(repo, exactRef.Hash())
+		require.NoError(t, err)
+		require.Nil(t, exact)
+		require.False(t, isExact)
+	})
 }
 
 func TestIsWorktreeDirty(t *testing.T) {

--- a/pkg/gitversion/repo_test.go
+++ b/pkg/gitversion/repo_test.go
@@ -82,8 +82,14 @@ func testRepoSingleCommitPastRelease(repo *git.Repository) (*git.Repository, err
 	if _, err := workTree.Add("hello-world2"); err != nil {
 		return nil, fmt.Errorf("worktree-add: %w", err)
 	}
-	if _, err := workTree.Commit("Subsequent Commit!", &git.CommitOptions{Author: testSignature}); err != nil {
+	postReleaseCommit, err := workTree.Commit("Subsequent Commit!", &git.CommitOptions{Author: testSignature});
+	if err != nil {
 		return nil, fmt.Errorf("commit: %w", err)
+	}
+
+	// make the commit after tag a new beta tag
+	if _, err := repo.CreateTag("v2.0.0-beta.1", postReleaseCommit, nil); err != nil {
+		return nil, fmt.Errorf("tag: %w", err)
 	}
 
 	return repo, nil


### PR DESCRIPTION
Before this change, if we are working in a v2.x.x version range, and
we would have created a v3.x.x-beta.1 tag, then pulumictl would use
that v3.0.0-beta.1 tag as the basis of the version calculation

```
▶ pulumictl get version
2.24.0-alpha.1617223100+d4d371d5

▶ git tag v3.0.0-beta.1

▶ pulumictl get version
3.0.0-beta.1+d4d371d5
```

This change will ignore beta and rc tags as part of the version calculation
as they can be cut at any time

```
▶ pulumictl get version
2.24.0-alpha.1617223100+d4d371d5

▶ git tag v3.0.0-beta.1

▶ pulumictl get version
2.24.0-alpha.1617223100+d4d371d5
```