### PR TITLE
Implement winget-deploy command

### DIFF
--- a/cmd/pulumictl/create/winget/cli.go
+++ b/cmd/pulumictl/create/winget/cli.go
@@ -1,0 +1,67 @@
+package winget
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/go-github/v32/github"
+	gh "github.com/pulumi/pulumictl/pkg/github"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	githubToken string
+	tokenClient *http.Client
+)
+
+const eventType = "winget-deploy"
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "winget-deploy",
+		Short: "Create a WinGet Deployment",
+		Long:  `Send a repository dispatch payload to the pulumi-winget repo that triggers the deployment of a winget package`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			// Grab all the configuration variables
+			githubToken = viper.GetString("token")
+			containerRepo := "pulumi/pulumi-winget"
+			// perform some string manipulation and validation
+			containerRepoArray := strings.Split(containerRepo, "/")
+
+			// if the string split doesn't return 2 values, it's probably not right
+			if len(containerRepoArray) != 2 {
+				return fmt.Errorf("unable to use container repo: format must be <org>/<repo> - value: %s\n", containerRepo)
+			}
+
+			// create a github client and token
+			ctx, client := gh.CreateGithubClient(githubToken)
+
+			// create an JSON payload
+			// pulumi-winget doesn't require a particular payload
+			emptyJsonPayload := "{}"
+			payload := json.RawMessage(emptyJsonPayload)
+
+			// create the repository dispatch event
+			_, _, err := client.Repositories.Dispatch(ctx,
+				containerRepoArray[0],
+				containerRepoArray[1],
+				github.DispatchRequestOptions{
+					EventType:     eventType,
+					ClientPayload: &payload,
+				})
+
+			if err != nil {
+				return fmt.Errorf("unable to create dispatch event: %w\n", err)
+			}
+
+			fmt.Println("Submitting dispatch event to:", containerRepo)
+			return nil
+		},
+	}
+	return command
+}

--- a/cmd/pulumictl/main.go
+++ b/cmd/pulumictl/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pulumi/pulumictl/cmd/pulumictl/copyright"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/cover"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/create"
+	"github.com/pulumi/pulumictl/cmd/pulumictl/create/winget"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/dispatch"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/generate"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/get"
@@ -35,6 +36,7 @@ func configureCLI() *cobra.Command {
 	rootCommand.AddCommand(copyright.Command())
 	rootCommand.AddCommand(generate.Command())
 	rootCommand.AddCommand(cover.Command())
+	rootCommand.AddCommand(winget.Command())
 
 	rootCommand.PersistentFlags().StringVarP(&githubToken, "token", "t", "", "a github token to use for making API calls to GitHub.")
 	rootCommand.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "enable debug logging")


### PR DESCRIPTION
Implements `pulumictl winget-deploy` command which sends a repository dispatch event to [pulumi-winget](https://github.com/pulumi/pulumi-winget) to trigger a deployment of winget. This is needed for [pulumi#4676](https://github.com/pulumi/pulumi/issues/4676)