### PR TITLE
Fix semver for dirty and exact tag

### DIFF
--- a/pkg/gitversion/gitversion.go
+++ b/pkg/gitversion/gitversion.go
@@ -71,9 +71,7 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 
 	// Check the shorthash
 	var shortHash string
-	if omitCommitHash || isPrerelease {
-		shortHash = ""
-	} else {
+	if !omitCommitHash && !isPrerelease {
 		shortHash = fmt.Sprintf("+%s", versionComponents.ShortHash)
 	}
 
@@ -110,8 +108,13 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 
 	// Detect if the git worktree is dirty, and add `dirty` to the version if it is
 	if versionComponents.Dirty {
-		preVersion = fmt.Sprintf("%s.dirty", preVersion)
+		separator := "."
+		if shortHash == "" || preVersion == "" {
+			// If we didn't add a short hash or a preversion then we need to seperate with + not .
+			separator = "+"
+		}
 		pythonPreVersion = fmt.Sprintf("%s+dirty", pythonPreVersion)
+		preVersion = fmt.Sprintf("%s%sdirty", preVersion, separator)
 	}
 
 	// a base version with the pre release info

--- a/pkg/gitversion/gitversion_test.go
+++ b/pkg/gitversion/gitversion_test.go
@@ -399,4 +399,35 @@ func TestGetVersion(t *testing.T) {
 		require.Equal(t, "v1.0.0", version.JavaScript)
 		require.Equal(t, "1.0.0", version.Python)
 	})
+
+	t.Run("Repo with exact tag and dirty", func(t *testing.T) {
+		repo, err := testRepoCreate()
+		require.NoError(t, err)
+		workTree, err := repo.Worktree()
+		require.NoError(t, err)
+
+		tagSequence := []string{
+			"v1.0.0",
+		}
+
+		repo, err = testRepoWithTags(repo, tagSequence)
+		require.NoError(t, err)
+
+		// Write a file but don't commit it
+		workDir := workTree.Filesystem
+		err = writeFile(workDir, "hello-world", "Hello World 2")
+		require.NoError(t, err)
+
+		opts := LanguageVersionsOptions{
+			Repo:      repo,
+			Commitish: plumbing.Revision("HEAD"),
+		}
+		version, err := GetLanguageVersionsWithOptions(opts)
+		require.NoError(t, err)
+
+		require.Equal(t, "1.0.0+dirty", version.SemVer)
+		require.Equal(t, "1.0.0+dirty", version.DotNet)
+		require.Equal(t, "v1.0.0+dirty", version.JavaScript)
+		require.Equal(t, "1.0.0+dirty", version.Python)
+	})
 }


### PR DESCRIPTION
This was printing as something like "1.0.0.dirty", when it should be "1.0.0+dirty"