### PR TITLE
Enable searching up to find the .git dir

### DIFF
--- a/cmd/pulumictl/get/version/cli.go
+++ b/cmd/pulumictl/get/version/cli.go
@@ -63,7 +63,9 @@ func Command() *cobra.Command {
 				}
 			}
 
-			repo, err := git.PlainOpenWithOptions(workingDir, &git.PlainOpenOptions{EnableDotGitCommonDir: true})
+			repo, err := git.PlainOpenWithOptions(workingDir, &git.PlainOpenOptions{
+				DetectDotGit:          true,
+				EnableDotGitCommonDir: true})
 			if err != nil {
 				return fmt.Errorf("error opening repository: %w", err)
 			}


### PR DESCRIPTION
Question of if we should only do this when "--repo" is unset, or if it's ok to do even if the user has given us a specific repo path?