### PR TITLE
Convert between version formats

### DIFF
--- a/cmd/pulumictl/convert-version/cli.go
+++ b/cmd/pulumictl/convert-version/cli.go
@@ -1,0 +1,66 @@
+package convertVersion
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var (
+	language string
+	version  string
+)
+
+func Command() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "convert-version",
+		Short: "Convert versions",
+		Long:  "Convert a generic version into a language specific version",
+		Args:  cobra.MaximumNArgs(1),
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmd.ParseFlags(args); err != nil {
+				return err
+			}
+
+			language = viper.GetString("language")
+			version = viper.GetString("version")
+
+			versions, err := gitversion.GetLanguageOptionsFromVersion(version)
+
+			if err != nil {
+				return fmt.Errorf("error calculating version: %w", err)
+			}
+
+			// FIXME: We could get the values here from the struct fields?
+			switch strings.ToLower(language) {
+			case "generic":
+				fmt.Println(versions.SemVer)
+			case "python":
+				fmt.Println(versions.Python)
+			case "javascript":
+				fmt.Println(versions.JavaScript)
+			case "dotnet":
+				fmt.Println(versions.DotNet)
+			default:
+				return fmt.Errorf("invalid language %q ", language)
+			}
+
+			return nil
+		},
+	}
+
+	command.Flags().StringVarP(&language, "language", "l", "", "the platform for which the version should be output.")
+	command.Flags().StringVarP(&version, "version", "v", "", "the generic version to convert (e.g. 3.0.0). Must be valid semver.")
+
+	viper.BindEnv("language", "PULUMI_LANGUAGE")
+	viper.BindPFlag("language", command.Flags().Lookup("language"))
+
+	viper.BindEnv("version", "VERSION")
+	viper.BindPFlag("version", command.Flags().Lookup("version"))
+
+	return command
+}

--- a/cmd/pulumictl/main.go
+++ b/cmd/pulumictl/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
-	download_binary "github.com/pulumi/pulumictl/cmd/pulumictl/download-binary"
 	"os"
+
+	download_binary "github.com/pulumi/pulumictl/cmd/pulumictl/download-binary"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	convert_version "github.com/pulumi/pulumictl/cmd/pulumictl/convert-Version"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/copyright"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/cover"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/create"
@@ -39,6 +41,7 @@ func configureCLI() *cobra.Command {
 	rootCommand.AddCommand(cover.Command())
 	rootCommand.AddCommand(winget.Command())
 	rootCommand.AddCommand(download_binary.Command())
+	rootCommand.AddCommand(convert_version.Command())
 
 	rootCommand.PersistentFlags().StringVarP(&githubToken, "token", "t", "", "a github token to use for making API calls to GitHub.")
 	rootCommand.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "enable debug logging")

--- a/cmd/pulumictl/main.go
+++ b/cmd/pulumictl/main.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	convert_version "github.com/pulumi/pulumictl/cmd/pulumictl/convert-Version"
+	convert_version "github.com/pulumi/pulumictl/cmd/pulumictl/convert-version"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/copyright"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/cover"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/create"

--- a/pkg/gitversion/convert.go
+++ b/pkg/gitversion/convert.go
@@ -71,11 +71,11 @@ func getPythonPreVersion(preVersion string) (string, error) {
 		remaining = strings.Replace(remaining, shortHash, "", 1)
 	}
 	// Find a number in the middle of non-words (- or .)
-	numRe := regexp.MustCompile(`\W(\d+)\W`)
+	numRe := regexp.MustCompile(`\W(\d+)(\W|$)`)
 	nums := numRe.FindStringSubmatch(remaining)
 	num := ""
 	// Our match group is in the 2nd array entry.
-	if len(nums) == 2 {
+	if len(nums) == 3 {
 		num = nums[1]
 	}
 
@@ -110,7 +110,7 @@ func getPythonPrePrefix(preVersion string) (string, string) {
 		return "d", preVersion[4:]
 	}
 	if strings.HasPrefix(preVersion, "-alpha") {
-		return "a", preVersion[5:]
+		return "a", preVersion[6:]
 	}
 	if strings.HasPrefix(preVersion, "-beta") {
 		return "b", preVersion[5:]

--- a/pkg/gitversion/convert.go
+++ b/pkg/gitversion/convert.go
@@ -1,0 +1,122 @@
+package gitversion
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func GetLanguageOptionsFromVersion(version string) (*LanguageVersions, error) {
+	// Strip leading "v" if present
+	normalised := version
+	if strings.HasPrefix(version, "v") {
+		normalised = version[1:]
+	}
+
+	parts := strings.SplitN(normalised, ".", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("version did not contain exactly 3 parts as expected: %q", version)
+	}
+
+	major := parts[0]
+	minor := parts[1]
+	patch := parts[2]
+
+	pythonPatch, err := convertPatchToPython(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	genericVersion := fmt.Sprintf("%s.%s.%s", major, minor, patch)
+	pythonVersion := fmt.Sprintf("%s.%s.%s", major, minor, pythonPatch)
+	jsVersion := fmt.Sprintf("v%s", genericVersion)
+	dotnetVersion := genericVersion
+
+	return &LanguageVersions{
+		SemVer:     genericVersion,
+		Python:     pythonVersion,
+		JavaScript: jsVersion,
+		DotNet:     dotnetVersion,
+	}, nil
+}
+
+func convertPatchToPython(patch string) (string, error) {
+	re := regexp.MustCompile(`^(\d+)(.*)$`)
+	matches := re.FindStringSubmatch(patch)
+	if len(matches) != 3 {
+		return patch, nil
+	}
+	version := matches[1]
+	pre := matches[2]
+	pythonPre, err := getPythonPreVersion(pre)
+	return version + pythonPre, err
+}
+
+func getPythonPreVersion(preVersion string) (string, error) {
+	if preVersion == "" {
+		return preVersion, nil
+	}
+
+	prefix, remaining := getPythonPrePrefix(preVersion)
+
+	isDirty := strings.Contains(preVersion, "dirty")
+	if isDirty {
+		remaining = strings.Replace(remaining, "dirty", "", 1)
+	}
+
+	// Find the hash and remove to make sure we don't pick up the hash as a number
+	hashRe := regexp.MustCompile(`[0-9a-f]{8}`)
+	shortHash := hashRe.FindString(remaining)
+	if shortHash != "" {
+		remaining = strings.Replace(remaining, shortHash, "", 1)
+	}
+	// Find a number in the middle of non-words (- or .)
+	numRe := regexp.MustCompile(`\W(\d+)\W`)
+	nums := numRe.FindStringSubmatch(remaining)
+	num := ""
+	// Our match group is in the 2nd array entry.
+	if len(nums) == 2 {
+		num = nums[1]
+	}
+
+	// Python uses PEP440, but Pypi has some curiosities.
+	pythonPreVersion := ""
+
+	// PEP440 (https://peps.python.org/pep-0440/) says pre-release parts MUST have a number in them,
+	// but we want to support tags like `v1.0.0-alpha`. If no number is present add `0` to keep PEP440
+	// happy.
+	var pythonPreSuffix string
+	if num == "" {
+		pythonPreSuffix = "0"
+	} else {
+		// Trim the initial "."
+		pythonPreSuffix = num
+	}
+
+	if prefix != "" {
+		pythonPreVersion = fmt.Sprintf("%s%s", prefix, pythonPreSuffix)
+	}
+
+	// Detect if the git worktree is dirty, and add `dirty` to the version if it is
+	if isDirty {
+		pythonPreVersion = fmt.Sprintf("%s+dirty", pythonPreVersion)
+	}
+
+	return pythonPreVersion, nil
+}
+
+func getPythonPrePrefix(preVersion string) (string, string) {
+	if strings.HasPrefix(preVersion, "-dev") {
+		return "d", preVersion[4:]
+	}
+	if strings.HasPrefix(preVersion, "-alpha") {
+		return "a", preVersion[5:]
+	}
+	if strings.HasPrefix(preVersion, "-beta") {
+		return "b", preVersion[5:]
+	}
+	if strings.HasPrefix(preVersion, "-rc") {
+		return "rc", preVersion[3:]
+	}
+	return "", ""
+}

--- a/pkg/gitversion/convert_test.go
+++ b/pkg/gitversion/convert_test.go
@@ -1,0 +1,116 @@
+package gitversion
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type versionTest struct {
+	desc   string
+	semver string
+	python string
+}
+
+func TestConversions(t *testing.T) {
+	inputs := []versionTest{
+		{
+			desc:   "Repo with exact tag",
+			semver: "1.0.0",
+			python: "1.0.0",
+		},
+		{
+			semver: "0.0.0",
+			python: "0.0.0",
+		},
+		{
+			desc:   "Repo with no tags",
+			semver: "0.0.1-alpha.0+68804cfa",
+			python: "0.0.1a0",
+		},
+		{
+			desc:   "Repo with no tags",
+			semver: "0.0.1-alpha.0+68804cfa",
+			python: "0.0.1a0",
+		},
+		{
+			desc:   "Repo with with commit after tag",
+			semver: "0.0.1-alpha.0+68804cfa",
+			python: "0.0.1a0",
+		},
+		{
+			desc:   "Repo with with commit after tag and dirty",
+			semver: "1.1.0-alpha.0+9fa804e8.dirty",
+			python: "1.1.0a0+dirty",
+		},
+		{
+			desc:   "Repo with no tags and dirty",
+			semver: "0.0.1-alpha.0+68804cfa.dirty",
+			python: "0.0.1a0+dirty",
+		},
+		{
+			desc:   "Repo with alpha tag and dirty",
+			semver: "1.0.0-alpha.1+e624a7d7.dirty",
+			python: "1.0.0a1+dirty",
+		},
+		{
+			desc:   "Repo with exact tag and dirty",
+			semver: "1.0.0+dirty",
+			python: "1.0.0+dirty",
+		},
+		{
+			desc:   "Repo with un-dotted alpha tag",
+			semver: "1.0.0-alpha+26d1c29c",
+			python: "1.0.0a0",
+		},
+		{
+			desc:   "Repo with un-dotted alpha tag marked for pre-release",
+			semver: "1.0.0-alpha",
+			python: "1.0.0a0",
+		},
+		{
+			desc:   "Repo with dotted alpha tag marked for pre-release",
+			semver: "1.0.0-alpha.1",
+			python: "1.0.0a1",
+		},
+		{
+			desc:   "Repo with beta tag and dirty",
+			semver: "1.0.0-beta.1+e624a7d7.dirty",
+			python: "1.0.0b1+dirty",
+		},
+		{
+			desc:   "Repo with rc tag and dirty",
+			semver: "1.0.0-rc.1+e624a7d7.dirty",
+			python: "1.0.0rc1+dirty",
+		},
+		{
+			desc:   "Repo with dev tag and dirty",
+			semver: "1.0.0-dev.1+e624a7d7.dirty",
+			python: "1.0.0d1+dirty",
+		},
+	}
+	for _, v := range inputs {
+		javascript := "v" + v.semver
+		desc := v.desc
+		if desc == "" {
+			desc = "test"
+		}
+		t.Run(fmt.Sprintf("%s %s", desc, v.semver), func(t *testing.T) {
+			v1, err := GetLanguageOptionsFromVersion(v.semver)
+			require.NoError(t, err)
+			require.Equal(t, v.semver, v1.SemVer)
+			require.Equal(t, v.semver, v1.DotNet)
+			require.Equal(t, javascript, v1.JavaScript)
+			require.Equal(t, v.python, v1.Python)
+
+			// Can round-trip from javascript too (with leading "v")
+			v2, err := GetLanguageOptionsFromVersion(javascript)
+			require.NoError(t, err)
+			require.Equal(t, v.semver, v2.SemVer)
+			require.Equal(t, v.semver, v2.DotNet)
+			require.Equal(t, javascript, v2.JavaScript)
+			require.Equal(t, v.python, v2.Python)
+		})
+	}
+}

--- a/pkg/gitversion/convert_test.go
+++ b/pkg/gitversion/convert_test.go
@@ -16,11 +16,6 @@ type versionTest struct {
 func TestConversions(t *testing.T) {
 	inputs := []versionTest{
 		{
-			desc:   "Repo with exact tag",
-			semver: "1.0.0",
-			python: "1.0.0",
-		},
-		{
 			semver: "0.0.0",
 			python: "0.0.0",
 		},
@@ -30,14 +25,14 @@ func TestConversions(t *testing.T) {
 			python: "0.0.1a0",
 		},
 		{
-			desc:   "Repo with no tags",
-			semver: "0.0.1-alpha.0+68804cfa",
-			python: "0.0.1a0",
+			desc:   "Repo with exact tag",
+			semver: "1.0.0",
+			python: "1.0.0",
 		},
 		{
 			desc:   "Repo with with commit after tag",
-			semver: "0.0.1-alpha.0+68804cfa",
-			python: "0.0.1a0",
+			semver: "1.1.0-alpha.0+9fa804e8",
+			python: "1.1.0a0",
 		},
 		{
 			desc:   "Repo with with commit after tag and dirty",

--- a/pkg/gitversion/gitversion.go
+++ b/pkg/gitversion/gitversion.go
@@ -140,14 +140,6 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 	jsVersion := fmt.Sprintf("v%s", version)
 	dotnetVersion := version
 
-	newLanguageVersions, err := GetLanguageOptionsFromVersion(version)
-	if err != nil {
-		return nil, err
-	}
-	if newLanguageVersions.Python != pythonVersion {
-		return nil, fmt.Errorf("expected %q found %q for %q", newLanguageVersions.Python, pythonVersion, version)
-	}
-
 	return &LanguageVersions{
 		SemVer:     version,
 		Python:     pythonVersion,

--- a/pkg/gitversion/gitversion.go
+++ b/pkg/gitversion/gitversion.go
@@ -131,14 +131,6 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 		preVersion = fmt.Sprintf("%s%sdirty", preVersion, separator)
 	}
 
-	newPythonPreVersion, err := getPythonPreVersion(preVersion)
-	if err != nil {
-		return nil, err
-	}
-	if newPythonPreVersion != pythonPreVersion {
-		return nil, fmt.Errorf("expected %q found %q for %q", pythonPreVersion, newPythonPreVersion, preVersion)
-	}
-
 	// a base version with the pre release info
 	baseVersion := fmt.Sprintf("%d.%d.%d", genericVersion.Major, genericVersion.Minor, genericVersion.Patch)
 
@@ -148,6 +140,14 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 	jsVersion := fmt.Sprintf("v%s", version)
 	dotnetVersion := version
 
+	newLanguageVersions, err := GetLanguageOptionsFromVersion(version)
+	if err != nil {
+		return nil, err
+	}
+	if newLanguageVersions.Python != pythonVersion {
+		return nil, fmt.Errorf("expected %q found %q for %q", newLanguageVersions.Python, pythonVersion, version)
+	}
+
 	return &LanguageVersions{
 		SemVer:     version,
 		Python:     pythonVersion,
@@ -156,22 +156,78 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 	}, nil
 }
 
+func GetLanguageOptionsFromVersion(version string) (*LanguageVersions, error) {
+	// Strip leading "v" if present
+	normalised := version
+	if strings.HasPrefix(version, "v") {
+		normalised = version[1:]
+	}
+
+	parts := strings.SplitN(normalised, ".", 3)
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("version did not contain exactly 3 parts as expected: %q", version)
+	}
+
+	major := parts[0]
+	minor := parts[1]
+	patch := parts[2]
+
+	pythonPatch, err := convertPatchToPython(patch)
+	if err != nil {
+		return nil, err
+	}
+
+	genericVersion := fmt.Sprintf("%s.%s.%s", major, minor, patch)
+	pythonVersion := fmt.Sprintf("%s.%s.%s", major, minor, pythonPatch)
+	jsVersion := fmt.Sprintf("v%s", genericVersion)
+	dotnetVersion := genericVersion
+
+	return &LanguageVersions{
+		SemVer:     genericVersion,
+		Python:     pythonVersion,
+		JavaScript: jsVersion,
+		DotNet:     dotnetVersion,
+	}, nil
+}
+
+func convertPatchToPython(patch string) (string, error) {
+	re := regexp.MustCompile(`^(\d+)(.*)$`)
+	matches := re.FindStringSubmatch(patch)
+	if len(matches) != 3 {
+		return patch, nil
+	}
+	version := matches[1]
+	pre := matches[2]
+	pythonPre, err := getPythonPreVersion(pre)
+	return version + pythonPre, err
+}
+
 func getPythonPreVersion(preVersion string) (string, error) {
 	if preVersion == "" {
 		return preVersion, nil
 	}
 
-	prefix, rest := getPythonPrePrefix(preVersion)
+	prefix, remaining := getPythonPrePrefix(preVersion)
+
+	isDirty := strings.Contains(preVersion, "dirty")
+	if isDirty {
+		remaining = strings.Replace(remaining, "dirty", "", 1)
+	}
+
+	// Find the hash and remove to make sure we don't pick up the hash as a number
+	hashRe := regexp.MustCompile(`[0-9a-f]{8}`)
+	shortHash := hashRe.FindString(remaining)
+	if shortHash != "" {
+		remaining = strings.Replace(remaining, shortHash, "", 1)
+	}
 	// Find a number in the middle of non-words (- or .)
 	numRe := regexp.MustCompile(`\W(\d+)\W`)
-	nums := numRe.FindStringSubmatch(rest)
+	nums := numRe.FindStringSubmatch(remaining)
 	num := ""
 	// Our match group is in the 2nd array entry.
 	if len(nums) == 2 {
 		num = nums[1]
 	}
-
-	isDirty := strings.Contains(preVersion, "dirty")
 
 	// Python uses PEP440, but Pypi has some curiosities.
 	pythonPreVersion := ""

--- a/pkg/gitversion/gitversion.go
+++ b/pkg/gitversion/gitversion.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os/exec"
 	"path"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -146,121 +145,6 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 		JavaScript: jsVersion,
 		DotNet:     dotnetVersion,
 	}, nil
-}
-
-func GetLanguageOptionsFromVersion(version string) (*LanguageVersions, error) {
-	// Strip leading "v" if present
-	normalised := version
-	if strings.HasPrefix(version, "v") {
-		normalised = version[1:]
-	}
-
-	parts := strings.SplitN(normalised, ".", 3)
-	if len(parts) != 3 {
-		return nil, fmt.Errorf("version did not contain exactly 3 parts as expected: %q", version)
-	}
-
-	major := parts[0]
-	minor := parts[1]
-	patch := parts[2]
-
-	pythonPatch, err := convertPatchToPython(patch)
-	if err != nil {
-		return nil, err
-	}
-
-	genericVersion := fmt.Sprintf("%s.%s.%s", major, minor, patch)
-	pythonVersion := fmt.Sprintf("%s.%s.%s", major, minor, pythonPatch)
-	jsVersion := fmt.Sprintf("v%s", genericVersion)
-	dotnetVersion := genericVersion
-
-	return &LanguageVersions{
-		SemVer:     genericVersion,
-		Python:     pythonVersion,
-		JavaScript: jsVersion,
-		DotNet:     dotnetVersion,
-	}, nil
-}
-
-func convertPatchToPython(patch string) (string, error) {
-	re := regexp.MustCompile(`^(\d+)(.*)$`)
-	matches := re.FindStringSubmatch(patch)
-	if len(matches) != 3 {
-		return patch, nil
-	}
-	version := matches[1]
-	pre := matches[2]
-	pythonPre, err := getPythonPreVersion(pre)
-	return version + pythonPre, err
-}
-
-func getPythonPreVersion(preVersion string) (string, error) {
-	if preVersion == "" {
-		return preVersion, nil
-	}
-
-	prefix, remaining := getPythonPrePrefix(preVersion)
-
-	isDirty := strings.Contains(preVersion, "dirty")
-	if isDirty {
-		remaining = strings.Replace(remaining, "dirty", "", 1)
-	}
-
-	// Find the hash and remove to make sure we don't pick up the hash as a number
-	hashRe := regexp.MustCompile(`[0-9a-f]{8}`)
-	shortHash := hashRe.FindString(remaining)
-	if shortHash != "" {
-		remaining = strings.Replace(remaining, shortHash, "", 1)
-	}
-	// Find a number in the middle of non-words (- or .)
-	numRe := regexp.MustCompile(`\W(\d+)\W`)
-	nums := numRe.FindStringSubmatch(remaining)
-	num := ""
-	// Our match group is in the 2nd array entry.
-	if len(nums) == 2 {
-		num = nums[1]
-	}
-
-	// Python uses PEP440, but Pypi has some curiosities.
-	pythonPreVersion := ""
-
-	// PEP440 (https://peps.python.org/pep-0440/) says pre-release parts MUST have a number in them,
-	// but we want to support tags like `v1.0.0-alpha`. If no number is present add `0` to keep PEP440
-	// happy.
-	var pythonPreSuffix string
-	if num == "" {
-		pythonPreSuffix = "0"
-	} else {
-		// Trim the initial "."
-		pythonPreSuffix = num
-	}
-
-	if prefix != "" {
-		pythonPreVersion = fmt.Sprintf("%s%s", prefix, pythonPreSuffix)
-	}
-
-	// Detect if the git worktree is dirty, and add `dirty` to the version if it is
-	if isDirty {
-		pythonPreVersion = fmt.Sprintf("%s+dirty", pythonPreVersion)
-	}
-
-	return pythonPreVersion, nil
-}
-
-func getPythonPrePrefix(preVersion string) (string, string) {
-	if strings.HasPrefix(preVersion, "-dev") {
-		return "d", preVersion[4:]
-	}
-	if strings.HasPrefix(preVersion, "-alpha") {
-		return "a", preVersion[5:]
-	}
-	if strings.HasPrefix(preVersion, "-beta") {
-		return "b", preVersion[5:]
-	}
-	if strings.HasPrefix(preVersion, "-rc") {
-		return "rc", preVersion[3:]
-	}
-	return "", ""
 }
 
 // See GetLanguageVersionsWithOptions.

--- a/pkg/gitversion/gitversion_test.go
+++ b/pkg/gitversion/gitversion_test.go
@@ -483,4 +483,29 @@ func TestGetVersion(t *testing.T) {
 		require.Equal(t, "v1.0.0-alpha", version.JavaScript)
 		require.Equal(t, "1.0.0a0", version.Python)
 	})
+
+	t.Run("Repo with dotted alpha tag marked for pre-release", func(t *testing.T) {
+		repo, err := testRepoCreate()
+		require.NoError(t, err)
+
+		tagSequence := []string{
+			"v1.0.0-alpha.1",
+		}
+
+		repo, err = testRepoWithTags(repo, tagSequence)
+		require.NoError(t, err)
+
+		opts := LanguageVersionsOptions{
+			IsPreRelease: true,
+			Repo:         repo,
+			Commitish:    plumbing.Revision("HEAD"),
+		}
+		version, err := GetLanguageVersionsWithOptions(opts)
+		require.NoError(t, err)
+
+		require.Equal(t, "1.0.0-alpha.1", version.SemVer)
+		require.Equal(t, "1.0.0-alpha.1", version.DotNet)
+		require.Equal(t, "v1.0.0-alpha.1", version.JavaScript)
+		require.Equal(t, "1.0.0a1", version.Python)
+	})
 }


### PR DESCRIPTION
Allows us to use pulumictl without interacting with git. Need for this is two-fold:

1. Allow us to convert between version without having to re-scan git logs which can take > 10 seconds and slows down the local dev loop.
2. Allow us to inject the version number into the makefile rather than the makefile interacting directly with git and just use pulumictl to convert the inputted, generic version number. This means that CI jobs can calculate the tag once at the beginning of the job, then skip having to pull the full history for every subsequent job (which can take > 10 minutes per job).

Example usage:
```
$ pulumictl convert-version -l python -v 3.0-alpha.2+dirty
3.0-alpha.2+dirty
$ pulumictl convert-version -l python -v v1.0.0-alpha.1+e624a7d7.dirt
1.0.0a1+dirty
```