### PR TITLE
Disable cgo

### DIFF
--- a/.goreleaser.prelease.yml
+++ b/.goreleaser.prelease.yml
@@ -3,7 +3,7 @@ before:
     - go mod download
 builds:
 - env:
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0
   goos:
     - darwin
     - windows

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
     - go mod download
 builds:
 - env:
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0
   goos:
     - darwin
     - windows
@@ -26,7 +26,7 @@ changelog:
 release:
   prerelease: auto
 brews:
-  - 
+  -
     name: pulumictl
     tap:
       owner: pulumi

--- a/fsnotify/go.mod
+++ b/fsnotify/go.mod
@@ -1,0 +1,3 @@
+module github.com/fsnotify/fsnotify
+
+go 1.19

--- a/fsnotify/stubs.go
+++ b/fsnotify/stubs.go
@@ -1,0 +1,33 @@
+package fsnotify
+
+type Op uint32
+
+type Event struct {
+	Name string
+	Op   Op
+}
+
+const (
+	Create Op = 1 << iota
+	Write
+	Remove
+	Rename
+	Chmod
+)
+
+type Watcher struct {
+	Events chan Event
+	Errors chan error
+}
+
+func (Watcher) Add(string) {
+	panic("fsnotify is not supported")
+}
+
+func (Watcher) Close() {
+	panic("fsnotify is not supported")
+}
+
+func NewWatcher() (*Watcher, error) {
+	panic("fsnotify is not supported")
+}

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/pulumi/pulumictl
 
 go 1.18
 
+replace github.com/fsnotify/fsnotify v1.6.0 => ./fsnotify
+
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar v1.3.4
@@ -64,7 +66,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/edsrzf/mmap-go v1.1.0 // indirect
 	github.com/emirpasic/gods v1.12.0 // indirect
-	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
@@ -151,7 +153,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220722155217-630584e8d5aa // indirect
 	golang.org/x/net v0.0.0-20220325170049-de3da57026de // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
-	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+	golang.org/x/sys v0.0.0-20220908164124-27713097b956 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 replace github.com/fsnotify/fsnotify v1.6.0 => ./fsnotify
 
+replace github.com/rjeczalik/notify v0.9.2 => ./notify
+
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/bmatcuk/doublestar v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -298,7 +298,6 @@ github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/frankban/quicktest v1.10.0 h1:Gfh+GAJZOAoKZsIZeZbdn2JF10kN1XHNvjsvQK8gVkE=
 github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813 h1:Uc+IZ7gYqAf/rSGFplbWBSHaGolEQlNLgMgSE3ccnIQ=
 github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813/go.mod h1:P+oSoE9yhSRvsmYyZsshflcR6ePWYLql6UU1amW13IM=
@@ -1060,8 +1059,8 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956 h1:XeJjHH1KiLpKGb6lvMiksZ9l0fVUh+AmGcm0nOMEBOY=
+golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/go.sum
+++ b/go.sum
@@ -698,8 +698,6 @@ github.com/pulumi/pulumi/sdk/v3 v3.38.0 h1:xqO+t81RDY9w+GT+YRUZDHuvfYEz+vgQBkdtL
 github.com/pulumi/pulumi/sdk/v3 v3.38.0/go.mod h1:3/6Fr/c01n7Hw7mtAlO7X8WMBgLP5AVTyYe4CRfJQc4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
-github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -979,7 +977,6 @@ golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20180926160741-c2ed4eda69e7/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/notify/go.mod
+++ b/notify/go.mod
@@ -1,0 +1,3 @@
+module github.com/rjeczalik/notify
+
+go 1.19

--- a/notify/stubs.go
+++ b/notify/stubs.go
@@ -1,0 +1,19 @@
+package notify
+
+type Event uint32
+
+type EventInfo interface {
+	Event() Event
+	Path() string
+	Sys() interface{}
+}
+
+func Stop(c chan<- EventInfo) {
+	panic("notify is not supported")
+}
+
+const All = 0
+
+func Watch(path string, c chan<- EventInfo, events ...Event) error {
+	panic("notify is not supported")
+}


### PR DESCRIPTION
Cross-compilation fails because of CGO, and we only need CGO for fsnotify dependency via Pulumi. I do not think it's used in pulumictl. These changes make `goreleaser build` succeed for me on Mac OS.

```
go mod why github.com/rjeczalik/notify                                                     
# github.com/rjeczalik/notify
github.com/pulumi/pulumictl/cmd/pulumictl/generate
github.com/pulumi/pulumi/pkg/v3/codegen/dotnet
github.com/pulumi/pulumi/pkg/v3/testing/integration
github.com/pulumi/pulumi/pkg/v3/backend/filestate
github.com/pulumi/pulumi/pkg/v3/backend
github.com/rjeczalik/notify

t0yv0@Antons-MacBook-Pro> go mod why github.com/fsnotify/fsnotify                                              
github.com/pulumi/pulumictl/cmd/pulumictl
github.com/spf13/viper
github.com/fsnotify/fsnotify
```

We'll lose some features of viper but I don't think those are in use; as to file state backend pulumictl should def not use that.