### PR TITLE
Fix argument parsing bugs by using dedicated Viper instances

### DIFF
--- a/cmd/pulumictl/convert-version/cli.go
+++ b/cmd/pulumictl/convert-version/cli.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -15,6 +15,8 @@ var (
 )
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
+
 	command := &cobra.Command{
 		Use:   "convert-version",
 		Short: "Convert versions",

--- a/cmd/pulumictl/create/azure/cli.go
+++ b/cmd/pulumictl/create/azure/cli.go
@@ -15,10 +15,8 @@ import (
 )
 
 var (
-	githubToken string
 	org         string
 	repo        string
-	ref         string
 	tokenClient *http.Client
 )
 
@@ -38,9 +36,9 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
-			githubToken = viper.GetString("token")
+			githubToken := viperlib.GetString("token")
 			org = viper.GetString("org")
-			ref = viper.GetString("ref")
+
 			containerRepo := "pulumi/pulumi-azure-nextgen"
 			ref := args[0]
 

--- a/cmd/pulumictl/create/azure/cli.go
+++ b/cmd/pulumictl/create/azure/cli.go
@@ -11,7 +11,7 @@ import (
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -29,6 +29,7 @@ type Payload struct {
 const eventType = "oss-sdk"
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "oss-sdk [gitRef]",
 		Short: "Publish the Azure Nextgen Provider SDK",

--- a/cmd/pulumictl/create/chocolatey/cli.go
+++ b/cmd/pulumictl/create/chocolatey/cli.go
@@ -11,7 +11,7 @@ import (
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -30,6 +30,7 @@ type Payload struct {
 const eventType = "choco-deploy"
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "choco-deploy [tag]",
 		Short: "Create a Chocolatey Deployment",

--- a/cmd/pulumictl/create/chocolatey/cli.go
+++ b/cmd/pulumictl/create/chocolatey/cli.go
@@ -18,7 +18,6 @@ var (
 	githubToken string
 	org         string
 	repo        string
-	ref         string
 	tokenClient *http.Client
 	app         string
 )
@@ -39,9 +38,8 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
-			githubToken = viper.GetString("token")
+			githubToken = viperlib.GetString("token")
 			org = viper.GetString("org")
-			ref = viper.GetString("ref")
 			containerRepo := "pulumi/pulumi-chocolatey"
 			ref := args[0]
 

--- a/cmd/pulumictl/create/cli-docs-build/cli.go
+++ b/cmd/pulumictl/create/cli-docs-build/cli.go
@@ -12,7 +12,7 @@ import (
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -30,6 +30,7 @@ type Payload struct {
 const eventType = "pulumi-cli"
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "cli-docs-build [tag]",
 		Short: "Create a docs build",

--- a/cmd/pulumictl/create/cli-docs-build/cli.go
+++ b/cmd/pulumictl/create/cli-docs-build/cli.go
@@ -16,10 +16,8 @@ import (
 )
 
 var (
-	githubToken string
 	org         string
 	repo        string
-	ref         string
 	tokenClient *http.Client
 )
 
@@ -39,9 +37,8 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
-			githubToken = viper.GetString("token")
+			githubToken := viperlib.GetString("token")
 			org = viper.GetString("org")
-			ref = viper.GetString("ref")
 			docsRepo := viper.GetString("docs-repo")
 			ref := args[0]
 

--- a/cmd/pulumictl/create/docs-build/cli.go
+++ b/cmd/pulumictl/create/docs-build/cli.go
@@ -16,10 +16,8 @@ import (
 )
 
 var (
-	githubToken string
 	org         string
 	repo        string
-	ref         string
 	category    string
 	displayName string
 	component   bool
@@ -53,9 +51,8 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
-			githubToken = viper.GetString("token")
+			githubToken := viperlib.GetString("token")
 			org = viper.GetString("org")
-			ref = viper.GetString("ref")
 			docsRepo := "pulumi/registry"
 			project := args[0]
 			ref := args[1]

--- a/cmd/pulumictl/create/docs-build/cli.go
+++ b/cmd/pulumictl/create/docs-build/cli.go
@@ -12,7 +12,7 @@ import (
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -44,6 +44,7 @@ type Payload struct {
 const eventType = "resource-provider"
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "docs-build [provider] [tag]",
 		Short: "Create a docs build",

--- a/cmd/pulumictl/create/homebrew/cli.go
+++ b/cmd/pulumictl/create/homebrew/cli.go
@@ -11,7 +11,7 @@ import (
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -31,6 +31,8 @@ type Payload struct {
 const eventType = "homebrew-bump"
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
+
 	command := &cobra.Command{
 		Use:   "homebrew-bump [tag]",
 		Short: "Create a Homebrew deployment",

--- a/cmd/pulumictl/create/homebrew/cli.go
+++ b/cmd/pulumictl/create/homebrew/cli.go
@@ -15,10 +15,8 @@ import (
 )
 
 var (
-	githubToken string
 	org         string
 	repo        string
-	ref         string
 	commitsha   string
 	tokenClient *http.Client
 )
@@ -41,7 +39,7 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
-			githubToken = viper.GetString("token")
+			githubToken := viperlib.GetString("token")
 			org = viper.GetString("org")
 			homebrewRepo := "pulumi/pulumi"
 			ref := args[0]

--- a/cmd/pulumictl/create/winget/cli.go
+++ b/cmd/pulumictl/create/winget/cli.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -20,6 +20,7 @@ var (
 const eventType = "winget-deploy"
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "winget-deploy",
 		Short: "Create a WinGet Deployment",

--- a/cmd/pulumictl/create/winget/cli.go
+++ b/cmd/pulumictl/create/winget/cli.go
@@ -13,14 +13,12 @@ import (
 )
 
 var (
-	githubToken string
 	tokenClient *http.Client
 )
 
 const eventType = "winget-deploy"
 
 func Command() *cobra.Command {
-	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "winget-deploy",
 		Short: "Create a WinGet Deployment",
@@ -29,7 +27,7 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
-			githubToken = viper.GetString("token")
+			githubToken := viperlib.GetString("token")
 			containerRepo := "pulumi/pulumi-winget"
 			// perform some string manipulation and validation
 			containerRepoArray := strings.Split(containerRepo, "/")

--- a/cmd/pulumictl/dispatch/cli.go
+++ b/cmd/pulumictl/dispatch/cli.go
@@ -12,7 +12,7 @@ import (
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -28,6 +28,8 @@ type Payload struct {
 }
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
+
 	command := &cobra.Command{
 		Use:   "dispatch [ref]",
 		Short: "Send a command dispatch event with a ref",

--- a/cmd/pulumictl/dispatch/cli.go
+++ b/cmd/pulumictl/dispatch/cli.go
@@ -16,7 +16,6 @@ import (
 )
 
 var (
-	githubToken string
 	org         string
 	repo        string
 	ref         string
@@ -38,9 +37,8 @@ func Command() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
-			githubToken = viper.GetString("token")
+			githubToken := viperlib.GetString("token")
 			org = viper.GetString("org")
-			ref = viper.GetString("ref")
 			repo := viper.GetString("repo")
 			command := viper.GetString("command")
 			ref := args[0]

--- a/cmd/pulumictl/get/latest_plugin/cli.go
+++ b/cmd/pulumictl/get/latest_plugin/cli.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pulumi/pulumictl/pkg/pluginversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -19,6 +19,7 @@ var (
 )
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "latest-plugin [provider]",
 		Short: "Get the latest available plugin",

--- a/cmd/pulumictl/get/latest_plugin/cli.go
+++ b/cmd/pulumictl/get/latest_plugin/cli.go
@@ -15,11 +15,9 @@ var (
 	version     string
 	exists      bool
 	tagsToCheck []string
-	githubToken string
 )
 
 func Command() *cobra.Command {
-	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "latest-plugin [provider]",
 		Short: "Get the latest available plugin",
@@ -31,7 +29,7 @@ func Command() *cobra.Command {
 			org, _ := cmd.Flags().GetString("org")
 			numOfTagsToCheck, _ := cmd.Flags().GetInt("num-tags")
 			project := args[0]
-			githubToken = viper.GetString("token")
+			githubToken := viperlib.GetString("token")
 
 			// create a github client and token
 			ctx, client := gh.CreateGithubClient(githubToken)

--- a/cmd/pulumictl/get/version/cli.go
+++ b/cmd/pulumictl/get/version/cli.go
@@ -10,7 +10,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 )
 
 var (
@@ -22,6 +22,7 @@ var (
 )
 
 func Command() *cobra.Command {
+	viper := viperlib.New()
 	command := &cobra.Command{
 		Use:   "version",
 		Short: "Calculate versions",

--- a/cmd/pulumictl/main.go
+++ b/cmd/pulumictl/main.go
@@ -7,7 +7,7 @@ import (
 	download_binary "github.com/pulumi/pulumictl/cmd/pulumictl/download-binary"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 
 	convert_version "github.com/pulumi/pulumictl/cmd/pulumictl/convert-version"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/copyright"
@@ -27,6 +27,9 @@ var (
 )
 
 func configureCLI() *cobra.Command {
+	// Using the shared global Viper instance for the top-level command. Sub-commands should use viperlib.New().
+	viper := viperlib.GetViper()
+
 	rootCommand := &cobra.Command{
 		Use:  "pulumictl",
 		Long: "A swiss army knife for Pulumi development",

--- a/pkg/gitversion/gitversion.go
+++ b/pkg/gitversion/gitversion.go
@@ -374,8 +374,7 @@ func mostRecentTag(repo *git.Repository, ref plumbing.Hash, isPrerelease bool,
 // has local modifications.
 func workTreeIsDirty(repo *git.Repository) (bool, error) {
 	// Using global viper state as "debug" is defined on the global Viper in main.go.
-	viper := viperlib.GetViper()
-	debug := viper.GetBool("debug")
+	debug := viperlib.GetBool("debug")
 	workTree, err := repo.Worktree()
 	if err != nil {
 		return false, fmt.Errorf("looking up worktree: %w", err)

--- a/pkg/gitversion/gitversion.go
+++ b/pkg/gitversion/gitversion.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/viper"
+	viperlib "github.com/spf13/viper"
 
 	"github.com/blang/semver"
 	"github.com/go-git/go-git/v5"
@@ -373,6 +373,8 @@ func mostRecentTag(repo *git.Repository, ref plumbing.Hash, isPrerelease bool,
 // workTreeIsDirty returns whether the worktree associated with the given repository
 // has local modifications.
 func workTreeIsDirty(repo *git.Repository) (bool, error) {
+	// Using global viper state as "debug" is defined on the global Viper in main.go.
+	viper := viperlib.GetViper()
 	debug := viper.GetBool("debug")
 	workTree, err := repo.Worktree()
 	if err != nil {


### PR DESCRIPTION
This stopped working as expected, instead generating a --generic style version:

```
pulumictl get version --language python
```

The first bad commit is f5ca64e and last good commit is 2218df7.

It turns out the issue is with viper arg parsing. Introducing a new "github.com/pulumi/pulumictl/cmd/pulumictl/convert-version" module with a new command reused the global viper instance. So this got called twice in different commands:

```
	viper.BindPFlag("language", command.Flags().Lookup("language"))
```

And it broke. Basically the new convert-version command broke the old `get version` command.

This is rather alarming, so the fix introduces dedicated viper state into every sub-command to avoid this collision in the future.