### PR TITLE
Fix converting to python version when the build number is 8 or more digits

### DIFF
--- a/pkg/gitversion/convert.go
+++ b/pkg/gitversion/convert.go
@@ -65,7 +65,7 @@ func getPythonPreVersion(preVersion string) (string, error) {
 	}
 
 	// Find the hash and remove to make sure we don't pick up the hash as a number
-	hashRe := regexp.MustCompile(`\b[0-9a-f]{8}\b`)
+	hashRe := regexp.MustCompile(`\+[0-9a-f]{8}\b`)
 	hashMatches := hashRe.FindAllString(remaining, 5)
 	if len(hashMatches) > 0 {
 		// Use the last match in case the build number is also exactly 8 digits long.

--- a/pkg/gitversion/convert.go
+++ b/pkg/gitversion/convert.go
@@ -65,9 +65,11 @@ func getPythonPreVersion(preVersion string) (string, error) {
 	}
 
 	// Find the hash and remove to make sure we don't pick up the hash as a number
-	hashRe := regexp.MustCompile(`[0-9a-f]{8}`)
-	shortHash := hashRe.FindString(remaining)
-	if shortHash != "" {
+	hashRe := regexp.MustCompile(`\b[0-9a-f]{8}\b`)
+	hashMatches := hashRe.FindAllString(remaining, 5)
+	if len(hashMatches) > 0 {
+		// Use the last match in case the build number is also exactly 8 digits long.
+		shortHash := hashMatches[len(hashMatches)-1]
 		remaining = strings.Replace(remaining, shortHash, "", 1)
 	}
 	// Find a number in the middle of non-words (- or .)

--- a/pkg/gitversion/convert_test.go
+++ b/pkg/gitversion/convert_test.go
@@ -89,6 +89,11 @@ func TestConversions(t *testing.T) {
 			semver: "1.93.1-alpha.1675198718+c586f7b1",
 			python: "1.93.1a1675198718",
 		},
+		{
+			desc:   "Master prerelease dirty",
+			semver: "1.93.1-alpha.1675198718+c586f7b1.dirty",
+			python: "1.93.1a1675198718+dirty",
+		},
 	}
 	for _, v := range inputs {
 		javascript := "v" + v.semver

--- a/pkg/gitversion/convert_test.go
+++ b/pkg/gitversion/convert_test.go
@@ -84,6 +84,11 @@ func TestConversions(t *testing.T) {
 			semver: "1.0.0-dev.1+e624a7d7.dirty",
 			python: "1.0.0d1+dirty",
 		},
+		{
+			desc:   "Master prerelease",
+			semver: "1.93.1-alpha.1675198718+c586f7b1",
+			python: "1.93.1a1675198718",
+		},
 	}
 	for _, v := range inputs {
 		javascript := "v" + v.semver


### PR DESCRIPTION
Ensure when we're detecting a hash that it's exactly 8 characters by checking for the word boundary. Always use the last match in case the build number preceding the hash is also exactly 8 digits.