### PR TITLE
fix: support tags with build info

### DIFF
--- a/pkg/gitversion/gitversion.go
+++ b/pkg/gitversion/gitversion.go
@@ -56,6 +56,8 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 	genericVersion.Major = versionComponents.Semver.Major
 	genericVersion.Minor = versionComponents.Semver.Minor
 	genericVersion.Patch = versionComponents.Semver.Patch
+	genericVersion.Build = versionComponents.Semver.Build
+
 	if len(versionComponents.Semver.Pre) == 1 {
 		genericVersion.Pre = []semver.PRVersion{
 			versionComponents.Semver.Pre[0],
@@ -130,12 +132,23 @@ func GetLanguageVersionsWithOptions(opts LanguageVersionsOptions) (*LanguageVers
 		preVersion = fmt.Sprintf("%s%sdirty", preVersion, separator)
 	}
 
+	buildVersion := []byte{}
+	if len(genericVersion.Build) > 0 {
+		buildVersion = append(buildVersion, '+')
+		buildVersion = append(buildVersion, genericVersion.Build[0]...)
+
+		for _, build := range genericVersion.Build[1:] {
+			buildVersion = append(buildVersion, '.')
+			buildVersion = append(buildVersion, build...)
+		}
+	}
+
 	// a base version with the pre release info
 	baseVersion := fmt.Sprintf("%d.%d.%d", genericVersion.Major, genericVersion.Minor, genericVersion.Patch)
 
 	// calculate versions for all languages
-	version := fmt.Sprintf("%s%s", baseVersion, preVersion)
-	pythonVersion := fmt.Sprintf("%s%s", baseVersion, pythonPreVersion)
+	version := fmt.Sprintf("%s%s%s", baseVersion, preVersion, buildVersion)
+	pythonVersion := fmt.Sprintf("%s%s%s", baseVersion, pythonPreVersion, buildVersion)
 	jsVersion := fmt.Sprintf("v%s", version)
 	dotnetVersion := version
 

--- a/pkg/gitversion/gitversion_test.go
+++ b/pkg/gitversion/gitversion_test.go
@@ -532,4 +532,28 @@ func TestGetVersion(t *testing.T) {
 		require.Equal(t, "v1.0.0+1", version.JavaScript)
 		require.Equal(t, "1.0.0+1", version.Python)
 	})
+
+	t.Run("Repo with complicated build info tag", func(t *testing.T) {
+		repo, err := testRepoCreate()
+		require.NoError(t, err)
+
+		tagSequence := []string{
+			"v1.0.0+1abc.345.whoop",
+		}
+
+		repo, err = testRepoWithTags(repo, tagSequence)
+		require.NoError(t, err)
+
+		opts := LanguageVersionsOptions{
+			Repo:      repo,
+			Commitish: plumbing.Revision("HEAD"),
+		}
+		version, err := GetLanguageVersionsWithOptions(opts)
+		require.NoError(t, err)
+
+		require.Equal(t, "1.0.0+1abc.345.whoop", version.SemVer)
+		require.Equal(t, "1.0.0+1abc.345.whoop", version.DotNet)
+		require.Equal(t, "v1.0.0+1abc.345.whoop", version.JavaScript)
+		require.Equal(t, "1.0.0+1abc.345.whoop", version.Python)
+	})
 }

--- a/pkg/gitversion/gitversion_test.go
+++ b/pkg/gitversion/gitversion_test.go
@@ -508,4 +508,28 @@ func TestGetVersion(t *testing.T) {
 		require.Equal(t, "v1.0.0-alpha.1", version.JavaScript)
 		require.Equal(t, "1.0.0a1", version.Python)
 	})
+
+	t.Run("Repo with build info tag", func(t *testing.T) {
+		repo, err := testRepoCreate()
+		require.NoError(t, err)
+
+		tagSequence := []string{
+			"v1.0.0+1",
+		}
+
+		repo, err = testRepoWithTags(repo, tagSequence)
+		require.NoError(t, err)
+
+		opts := LanguageVersionsOptions{
+			Repo:      repo,
+			Commitish: plumbing.Revision("HEAD"),
+		}
+		version, err := GetLanguageVersionsWithOptions(opts)
+		require.NoError(t, err)
+
+		require.Equal(t, "1.0.0+1", version.SemVer)
+		require.Equal(t, "1.0.0+1", version.DotNet)
+		require.Equal(t, "v1.0.0+1", version.JavaScript)
+		require.Equal(t, "1.0.0+1", version.Python)
+	})
 }


### PR DESCRIPTION
When briding a Terraform provider, it makes
a lot of sense to match the Terraform provider
version in the Pulumi provider.

However, there needs to be a clean way to increment this build while keeping the Terraform version static, without abusing prerelease tags.

This is supported by build metadata:
https://semver.org/spec/v2.0.0.html