### PR TITLE
Modernize

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install Go 1.21
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21.x'
       - name: Run tests

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:    
   tests:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -19,3 +20,6 @@ jobs:
         run: |
           make install
           pulumictl convert-version -v 0.0.1+dev -l python
+  lint:
+    name: Lint
+    uses: ./.github/workflows/stage-lint.yml

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Go 1.18
+      - name: Install Go 1.21
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.x'
+          go-version: '1.21.x'
       - name: Run tests
         run: go test ./...
       - name: Install and run

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow clone
         run: git fetch --prune --unshallow
-      - name: Install Go 1.18
+      - name: Install Go 1.21
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.x'
+          go-version: '1.21.x'
       - name: Goreleaser publish
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Unshallow clone
         run: git fetch --prune --unshallow
       - name: Install Go 1.21
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21.x'
       - name: Goreleaser publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow clone
         run: git fetch --prune --unshallow
-      - name: Install Go 1.18
+      - name: Install Go 1.21
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.x'
+          go-version: '1.21.x'
       - name: Goreleaser publish
         uses: goreleaser/goreleaser-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Unshallow clone
         run: git fetch --prune --unshallow
       - name: Install Go 1.21
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '1.21.x'
       - name: Goreleaser publish

--- a/.github/workflows/stage-lint.yml
+++ b/.github/workflows/stage-lint.yml
@@ -1,0 +1,28 @@
+name: Lint
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  lint:
+    name: golangci
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Install Go 1.21
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.21'
+        cache: false
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: v1.54
+        working-directory: cmd

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+bin
+
 ### macOS template
 # General
 .DS_Store

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,20 +3,18 @@ run:
 linters:
   enable-all: false
   enable:
-    - deadcode
+    - revive
+    - unused
     - errcheck
     - goconst
     - gofmt
-    - golint
     - gosec
     - govet
     - ineffassign
     - lll
     - misspell
     - nakedret
-    - structcheck
     - unconvert
-    - varcheck
   disable:
     - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
     - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 ROOT_DIR := $(shell pwd)
 
 
+bin:
+	mkdir -p bin
 
-build:
-	cd cmd/pulumictl && go build
-	mv cmd/pulumictl/pulumictl ${ROOT_DIR}/
+build: bin
+	go build -C cmd/pulumictl -o ${ROOT_DIR}/bin
 
 install:
-	cd cmd/pulumictl && go install
+	go -C cmd/pulumictl install
 
 clean:
-	rm -f pulumictl
+	rm -rf bin
 
 lint:
 	cd cmd && golangci-lint run -c ../.golangci.yml --timeout 5m

--- a/cmd/pulumictl/convert-version/cli.go
+++ b/cmd/pulumictl/convert-version/cli.go
@@ -1,4 +1,4 @@
-package convertVersion
+package convertVersion //nolint:revive // backwards compatibility
 
 import (
 	"fmt"

--- a/cmd/pulumictl/convert-version/cli.go
+++ b/cmd/pulumictl/convert-version/cli.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/pulumi/pulumictl/pkg/util"
 	"github.com/spf13/cobra"
 	viperlib "github.com/spf13/viper"
 )
@@ -55,14 +56,18 @@ func Command() *cobra.Command {
 		},
 	}
 
-	command.Flags().StringVarP(&language, "language", "l", "", "the platform for which the version should be output.")
-	command.Flags().StringVarP(&version, "version", "v", "", "the generic version to convert (e.g. 3.0.0). Must be valid semver.")
+	command.Flags().StringVarP(&language,
+		"language", "l", "",
+		"the platform for which the version should be output.")
+	command.Flags().StringVarP(&version,
+		"version", "v", "",
+		"the generic version to convert (e.g. 3.0.0). Must be valid semver.")
 
-	viper.BindEnv("language", "PULUMI_LANGUAGE")
-	viper.BindPFlag("language", command.Flags().Lookup("language"))
+	util.NoErr(viper.BindEnv("language", "PULUMI_LANGUAGE"))
+	util.NoErr(viper.BindPFlag("language", command.Flags().Lookup("language")))
 
-	viper.BindEnv("version", "VERSION")
-	viper.BindPFlag("version", command.Flags().Lookup("version"))
+	util.NoErr(viper.BindEnv("version", "VERSION"))
+	util.NoErr(viper.BindPFlag("version", command.Flags().Lookup("version")))
 
 	return command
 }

--- a/cmd/pulumictl/copyright/cli.go
+++ b/cmd/pulumictl/copyright/cli.go
@@ -115,7 +115,7 @@ Files missing a Copyright notice:
 			fmt.Printf("%s\n", f)
 		}
 
-		return fmt.Errorf("Found %d source files missing a Copyright notice\n", len(files))
+		return fmt.Errorf("found %d source files missing a Copyright notice", len(files))
 	}
 	return nil
 }

--- a/cmd/pulumictl/copyright/cli.go
+++ b/cmd/pulumictl/copyright/cli.go
@@ -57,11 +57,8 @@ func Command() *cobra.Command {
 
 			if fixup {
 				return c.executeFixup()
-			} else {
-				return c.executeCheck()
 			}
-
-			return nil
+			return c.executeCheck()
 		},
 	}
 
@@ -69,7 +66,7 @@ func Command() *cobra.Command {
 	command.Flags().Bool("fixup", false, "edit files to comply")
 	command.Flags().Int("parallelism", 8, "parallelism level to use")
 	command.Flags().Int("lines", 20, "max head lines to scan in each file")
-	command.Flags().StringP("exclude", "x", "", "patterns to exclude from copyright checks (',' seperated)")
+	command.Flags().StringP("exclude", "x", "", "patterns to exclude from copyright checks (',' separated)")
 
 	return command
 }
@@ -87,10 +84,10 @@ type checker struct {
 func newChecker(repo string, exclude []string, headLineLimit int, parallelism int) *checker {
 	srcP := regexp.MustCompile(`[.](py|ts|cs|go)$`)
 	copyP := regexp.MustCompile(`Copyright (20..-20..|20..), Pulumi Corporation`)
-	copy := fmt.Sprintf("Copyright %d, Pulumi Corporation.  All rights reserved.",
+	copyrightNotice := fmt.Sprintf("Copyright %d, Pulumi Corporation.  All rights reserved.",
 		time.Now().Year())
 	return &checker{
-		copyrightNotice:      copy,
+		copyrightNotice:      copyrightNotice,
 		repo:                 repo,
 		exclude:              exclude,
 		sourceFilePattern:    srcP,
@@ -119,9 +116,8 @@ Files missing a Copyright notice:
 		}
 
 		return fmt.Errorf("Found %d source files missing a Copyright notice\n", len(files))
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func (c *checker) executeFixup() error {
@@ -170,19 +166,14 @@ func (c *checker) fixupFile(filename string) error {
 		return err
 	}
 
-	if err = w.Flush(); err != nil {
-		return err
-	}
-
-	return nil
+	return w.Flush()
 }
 
 func commentPrefixByFilename(filename string) string {
 	if strings.HasSuffix(filename, ".py") {
 		return "#"
-	} else {
-		return "//"
 	}
+	return "//"
 }
 
 func (c *checker) findAllFiles() ([]string, error) {

--- a/cmd/pulumictl/cover/merge.go
+++ b/cmd/pulumictl/cover/merge.go
@@ -160,7 +160,8 @@ func coverCommand() *cobra.Command {
 		},
 	}
 
-	command.PersistentFlags().StringVarP(&inPath, "in", "i", "", "the path to the directory containing coverage data to merge")
+	command.PersistentFlags().StringVarP(&inPath,
+		"in", "i", "", "the path to the directory containing coverage data to merge")
 	command.PersistentFlags().StringVarP(&outPath, "out", "o", "", "the path to the output file")
 
 	return command

--- a/cmd/pulumictl/create/azure/cli.go
+++ b/cmd/pulumictl/create/azure/cli.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/google/go-github/v32/github"
-	gh "github.com/pulumi/pulumictl/pkg/github"
-	"github.com/pulumi/pulumictl/pkg/gitversion"
 	"github.com/spf13/cobra"
 	viperlib "github.com/spf13/viper"
+
+	gh "github.com/pulumi/pulumictl/pkg/github"
+	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/pulumi/pulumictl/pkg/util"
 )
 
 var (
@@ -47,13 +49,13 @@ func Command() *cobra.Command {
 
 			// if the string split doesn't return 2 values, it's probably not right
 			if len(containerRepoArray) != 2 {
-				return fmt.Errorf("unable to use container repo: format must be <org>/<repo> - value: %s\n", containerRepo)
+				return fmt.Errorf("unable to use container repo: format must be <org>/<repo> - value: %s", containerRepo)
 			}
 
 			_, err := semver.Parse(gitversion.StripModuleTagPrefixes(ref))
 
 			if err != nil {
-				return fmt.Errorf("must specify a valid semver ref - value: %s\n", ref)
+				return fmt.Errorf("must specify a valid semver ref - value: %s", ref)
 			}
 
 			// create a github client and token
@@ -79,7 +81,7 @@ func Command() *cobra.Command {
 				})
 
 			if err != nil {
-				return fmt.Errorf("unable to create dispatch event: %w\n", err)
+				return fmt.Errorf("unable to create dispatch event: %w", err)
 			}
 
 			// output stuff
@@ -93,8 +95,8 @@ func Command() *cobra.Command {
 
 	command.Flags().StringP("org", "o", "pulumi", "the GitHub org that hosts the provider in the arg")
 
-	viper.BindEnv("org", "GITHUB_ORG")
-	viper.BindPFlag("org", command.Flags().Lookup("org"))
+	util.NoErr(viper.BindEnv("org", "GITHUB_ORG"))
+	util.NoErr(viper.BindPFlag("org", command.Flags().Lookup("org")))
 
 	return command
 }

--- a/cmd/pulumictl/create/chocolatey/cli.go
+++ b/cmd/pulumictl/create/chocolatey/cli.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/pulumi/pulumictl/pkg/util"
 	"github.com/spf13/cobra"
 	viperlib "github.com/spf13/viper"
 )
@@ -33,8 +34,10 @@ func Command() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "choco-deploy [tag]",
 		Short: "Create a Chocolatey Deployment",
-		Long:  `Send a repository dispatch payload to the pulumi-chocolatey repo that triggers the deployment of a chocolatey package`,
-		Args:  cobra.ExactArgs(1),
+		Long: "Send a repository dispatch payload to the" +
+			" pulumi-chocolatey repo that triggers the" +
+			" deployment of a chocolatey package",
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
@@ -50,12 +53,14 @@ func Command() *cobra.Command {
 
 			// if the string split doesn't return 2 values, it's probably not right
 			if len(containerRepoArray) != 2 {
-				return fmt.Errorf("unable to use container repo: format must be <org>/<repo> - value: %s\n", containerRepo)
+				return fmt.Errorf("unable to use container repo:"+
+					" format must be <org>/<repo> - value: %s",
+					containerRepo)
 			}
 
 			_, err := semver.Parse(gitversion.StripModuleTagPrefixes(ref))
 			if err != nil {
-				return fmt.Errorf("must specify a valid semver ref - value: %s\n", ref)
+				return fmt.Errorf("must specify a valid semver ref - value: %s", ref)
 			}
 
 			// create a github client and token
@@ -88,7 +93,7 @@ func Command() *cobra.Command {
 				})
 
 			if err != nil {
-				return fmt.Errorf("unable to create dispatch event: %w\n", err)
+				return fmt.Errorf("unable to create dispatch event: %w", err)
 			}
 
 			// output stuff
@@ -103,9 +108,9 @@ func Command() *cobra.Command {
 	command.Flags().StringP("org", "o", "pulumi", "the GitHub org that hosts the provider in the arg")
 	command.Flags().StringP("app", "a", "", "The name of the chocolatey application to deploy")
 
-	viper.BindEnv("org", "GITHUB_ORG")
-	viper.BindPFlag("org", command.Flags().Lookup("org"))
-	viper.BindPFlag("app", command.Flags().Lookup("app"))
+	util.NoErr(viper.BindEnv("org", "GITHUB_ORG"))
+	util.NoErr(viper.BindPFlag("org", command.Flags().Lookup("org")))
+	util.NoErr(viper.BindPFlag("app", command.Flags().Lookup("app")))
 
 	return command
 }

--- a/cmd/pulumictl/create/cli-docs-build/cli.go
+++ b/cmd/pulumictl/create/cli-docs-build/cli.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/pulumi/pulumictl/pkg/util"
 	"github.com/spf13/cobra"
 	viperlib "github.com/spf13/viper"
 )
@@ -47,13 +48,15 @@ func Command() *cobra.Command {
 
 			// if the string split doesn't return 2 values, it's probably not right
 			if len(docsRepoArray) != 2 {
-				return fmt.Errorf("unable to use docs repo: format must be <org>/<repo> - value: %s\n", docsRepo)
+				return fmt.Errorf("unable to use docs repo:"+
+					" format must be <org>/<repo> - value: %s",
+					docsRepo)
 			}
 
 			_, err := semver.Parse(gitversion.StripModuleTagPrefixes(ref))
 
 			if err != nil {
-				return fmt.Errorf("must specify a valid semver ref - value: %s\n", ref)
+				return fmt.Errorf("must specify a valid semver ref - value: %s", ref)
 			}
 
 			// create a github client and token
@@ -79,7 +82,7 @@ func Command() *cobra.Command {
 				})
 
 			if err != nil {
-				return fmt.Errorf("unable to create dispatch event: %w\n", err)
+				return fmt.Errorf("unable to create dispatch event: %w", err)
 			}
 
 			// output stuff
@@ -94,10 +97,10 @@ func Command() *cobra.Command {
 	command.Flags().StringP("org", "o", "pulumi", "the GitHub org that hosts the provider in the arg")
 	command.Flags().StringP("docs-repo", "d", "pulumi/docs", "the docs repository to send in the payload")
 
-	viper.BindEnv("org", "GITHUB_ORG")
-	viper.BindEnv("docs-repo", "GITHUB_DOCS_REPO")
-	viper.BindPFlag("org", command.Flags().Lookup("org"))
-	viper.BindPFlag("docs-repo", command.Flags().Lookup("docs-repo"))
+	util.NoErr(viper.BindEnv("org", "GITHUB_ORG"))
+	util.NoErr(viper.BindEnv("docs-repo", "GITHUB_DOCS_REPO"))
+	util.NoErr(viper.BindPFlag("org", command.Flags().Lookup("org")))
+	util.NoErr(viper.BindPFlag("docs-repo", command.Flags().Lookup("docs-repo")))
 
 	return command
 }

--- a/cmd/pulumictl/create/docs-build/cli.go
+++ b/cmd/pulumictl/create/docs-build/cli.go
@@ -28,7 +28,7 @@ var (
 
 type Payload struct {
 	Repo             string `json:"repo"`
-	Org              string `json:"org"'`
+	Org              string `json:"org"`
 	Project          string `json:"project"`
 	ProjectShortname string `json:"project-shortname"`
 	Ref              string `json:"ref"`

--- a/cmd/pulumictl/create/docs-build/cli.go
+++ b/cmd/pulumictl/create/docs-build/cli.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/pulumi/pulumictl/pkg/util"
 	"github.com/spf13/cobra"
 	viperlib "github.com/spf13/viper"
 )
@@ -72,13 +73,13 @@ func Command() *cobra.Command {
 
 			// if the string split doesn't return 2 values, it's probably not right
 			if len(docsRepoArray) != 2 {
-				return fmt.Errorf("unable to use docs repo: format must be <org>/<repo> - value: %s\n", docsRepo)
+				return fmt.Errorf("unable to use docs repo: format must be <org>/<repo> - value: %s", docsRepo)
 			}
 
 			_, err := semver.Parse(gitversion.StripModuleTagPrefixes(ref))
 
 			if err != nil {
-				return fmt.Errorf("must specify a valid semver ref - value: %s\n", ref)
+				return fmt.Errorf("must specify a valid semver ref - value: %s", ref)
 			}
 
 			// create a github client and token
@@ -113,7 +114,7 @@ func Command() *cobra.Command {
 				})
 
 			if err != nil {
-				return fmt.Errorf("unable to create dispatch event: %w\n", err)
+				return fmt.Errorf("unable to create dispatch event: %w", err)
 			}
 
 			// output stuff
@@ -132,18 +133,18 @@ func Command() *cobra.Command {
 	command.Flags().String("schema-path", "", "the path (relative to repo root) to the schema.yaml/json file")
 	command.Flags().String("publisher", "", "the name of the provider/component publisher")
 
-	viper.BindEnv("org", "GITHUB_ORG")
-	viper.BindEnv("category", "PROVIDER_CATEGORY")
-	viper.BindEnv("display-name", "PROVIDER_DISPLAY_NAME")
-	viper.BindEnv("is-component", "PROVIDER_IS_COMPONENT")
-	viper.BindEnv("schema-path", "PROVIDER_SCHEMA_PATH")
-	viper.BindEnv("publisher", "PROVIDER_PUBLISHER_NAME")
-	viper.BindPFlag("org", command.Flags().Lookup("org"))
-	viper.BindPFlag("category", command.Flags().Lookup("category"))
-	viper.BindPFlag("display-name", command.Flags().Lookup("display-name"))
-	viper.BindPFlag("is-component", command.Flags().Lookup("is-component"))
-	viper.BindPFlag("schema-path", command.Flags().Lookup("schema-path"))
-	viper.BindPFlag("publisher", command.Flags().Lookup("publisher"))
+	util.NoErr(viper.BindEnv("org", "GITHUB_ORG"))
+	util.NoErr(viper.BindEnv("category", "PROVIDER_CATEGORY"))
+	util.NoErr(viper.BindEnv("display-name", "PROVIDER_DISPLAY_NAME"))
+	util.NoErr(viper.BindEnv("is-component", "PROVIDER_IS_COMPONENT"))
+	util.NoErr(viper.BindEnv("schema-path", "PROVIDER_SCHEMA_PATH"))
+	util.NoErr(viper.BindEnv("publisher", "PROVIDER_PUBLISHER_NAME"))
+	util.NoErr(viper.BindPFlag("org", command.Flags().Lookup("org")))
+	util.NoErr(viper.BindPFlag("category", command.Flags().Lookup("category")))
+	util.NoErr(viper.BindPFlag("display-name", command.Flags().Lookup("display-name")))
+	util.NoErr(viper.BindPFlag("is-component", command.Flags().Lookup("is-component")))
+	util.NoErr(viper.BindPFlag("schema-path", command.Flags().Lookup("schema-path")))
+	util.NoErr(viper.BindPFlag("publisher", command.Flags().Lookup("publisher")))
 
 	return command
 }

--- a/cmd/pulumictl/create/homebrew/cli.go
+++ b/cmd/pulumictl/create/homebrew/cli.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/pulumi/pulumictl/pkg/util"
 	"github.com/spf13/cobra"
 	viperlib "github.com/spf13/viper"
 )
@@ -34,8 +35,9 @@ func Command() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "homebrew-bump [tag]",
 		Short: "Create a Homebrew deployment",
-		Long:  `Send a repository dispatch payload to the pulumi repo that triggers the deployment of a homebrew formulae bump`,
-		Args:  cobra.ExactArgs(2),
+		Long: "Send a repository dispatch payload to the pulumi repo that triggers" +
+			" the deployment of a homebrew formulae bump",
+		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
@@ -50,13 +52,13 @@ func Command() *cobra.Command {
 
 			// if the string split doesn't return 2 values, it's probably not right
 			if len(containerRepoArray) != 2 {
-				return fmt.Errorf("unable to use container repo: format must be <org>/<repo> - value: %s\n", homebrewRepo)
+				return fmt.Errorf("unable to use container repo: format must be <org>/<repo> - value: %s", homebrewRepo)
 			}
 
 			_, err := semver.Parse(gitversion.StripModuleTagPrefixes(ref))
 
 			if err != nil {
-				return fmt.Errorf("must specify a valid semver ref - value: %s\n", ref)
+				return fmt.Errorf("must specify a valid semver ref - value: %s", ref)
 			}
 
 			// create a github client and token
@@ -83,7 +85,7 @@ func Command() *cobra.Command {
 				})
 
 			if err != nil {
-				return fmt.Errorf("unable to create dispatch event: %w\n", err)
+				return fmt.Errorf("unable to create dispatch event: %w", err)
 			}
 
 			// output stuff
@@ -97,8 +99,8 @@ func Command() *cobra.Command {
 
 	command.Flags().StringP("org", "o", "pulumi", "the GitHub org that hosts the provider in the arg")
 
-	viper.BindEnv("org", "GITHUB_ORG")
-	viper.BindPFlag("org", command.Flags().Lookup("org"))
+	util.NoErr(viper.BindEnv("org", "GITHUB_ORG"))
+	util.NoErr(viper.BindPFlag("org", command.Flags().Lookup("org")))
 
 	return command
 }

--- a/cmd/pulumictl/create/winget/cli.go
+++ b/cmd/pulumictl/create/winget/cli.go
@@ -22,8 +22,9 @@ func Command() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "winget-deploy",
 		Short: "Create a WinGet Deployment",
-		Long:  `Send a repository dispatch payload to the pulumi-winget repo that triggers the deployment of a winget package`,
-		Args:  cobra.NoArgs,
+		Long: "Send a repository dispatch payload to the pulumi-winget " +
+			"repo that triggers the deployment of a winget package",
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			// Grab all the configuration variables
@@ -34,7 +35,9 @@ func Command() *cobra.Command {
 
 			// if the string split doesn't return 2 values, it's probably not right
 			if len(containerRepoArray) != 2 {
-				return fmt.Errorf("unable to use container repo: format must be <org>/<repo> - value: %s\n", containerRepo)
+				return fmt.Errorf("unable to use container repo:"+
+					" format must be <org>/<repo> - value:"+
+					" %s\n", containerRepo)
 			}
 
 			// create a github client and token
@@ -42,8 +45,8 @@ func Command() *cobra.Command {
 
 			// create an JSON payload
 			// pulumi-winget doesn't require a particular payload
-			emptyJsonPayload := "{}"
-			payload := json.RawMessage(emptyJsonPayload)
+			emptyJSONPayload := "{}"
+			payload := json.RawMessage(emptyJSONPayload)
 
 			// create the repository dispatch event
 			_, _, err := client.Repositories.Dispatch(ctx,

--- a/cmd/pulumictl/create/winget/cli.go
+++ b/cmd/pulumictl/create/winget/cli.go
@@ -58,7 +58,7 @@ func Command() *cobra.Command {
 				})
 
 			if err != nil {
-				return fmt.Errorf("unable to create dispatch event: %w\n", err)
+				return fmt.Errorf("unable to create dispatch event: %w", err)
 			}
 
 			fmt.Println("Submitting dispatch event to:", containerRepo)

--- a/cmd/pulumictl/dispatch/cli.go
+++ b/cmd/pulumictl/dispatch/cli.go
@@ -11,6 +11,7 @@ import (
 	"github.com/google/go-github/v32/github"
 	gh "github.com/pulumi/pulumictl/pkg/github"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/pulumi/pulumictl/pkg/util"
 	"github.com/spf13/cobra"
 	viperlib "github.com/spf13/viper"
 )
@@ -48,13 +49,13 @@ func Command() *cobra.Command {
 
 			// if the string split doesn't return 2 values, it's probably not right
 			if len(repoArray) != 2 {
-				return fmt.Errorf("unable to use repo: format must be <org>/<repo> - value: %s\n", repo)
+				return fmt.Errorf("unable to use repo: format must be <org>/<repo> - value: %s", repo)
 			}
 
 			_, err := semver.Parse(gitversion.StripModuleTagPrefixes(ref))
 
 			if err != nil {
-				return fmt.Errorf("must specify a valid semver ref - value: %s\n", ref)
+				return fmt.Errorf("must specify a valid semver ref - value: %s", ref)
 			}
 
 			// create a github client and token
@@ -80,7 +81,7 @@ func Command() *cobra.Command {
 				})
 
 			if err != nil {
-				return fmt.Errorf("unable to create dispatch event: %w\n", err)
+				return fmt.Errorf("unable to create dispatch event: %w", err)
 			}
 
 			// output stuff
@@ -96,9 +97,9 @@ func Command() *cobra.Command {
 	command.Flags().StringP("repo", "r", "", "the repository to send in the payload")
 	command.Flags().StringP("command", "c", "", "The repository dispatch command to trigger")
 
-	viper.BindPFlag("org", command.Flags().Lookup("org"))
-	viper.BindPFlag("repo", command.Flags().Lookup("repo"))
-	viper.BindPFlag("command", command.Flags().Lookup("command"))
+	util.NoErr(viper.BindPFlag("org", command.Flags().Lookup("org")))
+	util.NoErr(viper.BindPFlag("repo", command.Flags().Lookup("repo")))
+	util.NoErr(viper.BindPFlag("command", command.Flags().Lookup("command")))
 
 	return command
 }

--- a/cmd/pulumictl/download-binary/cli.go
+++ b/cmd/pulumictl/download-binary/cli.go
@@ -75,9 +75,9 @@ func Command() *cobra.Command {
 		"host", "https://github.com", "The host of the repo to download from. "+
 			"Defaults to https://github.com")
 
-	util.NoErr(cmd.MarkFlagRequired("repo-slug"))
-	util.NoErr(cmd.MarkFlagRequired("name"))
-	util.NoErr(cmd.MarkFlagRequired("version"))
+	util.Ignore(cmd.MarkFlagRequired("repo-slug"))
+	util.Ignore(cmd.MarkFlagRequired("name"))
+	util.Ignore(cmd.MarkFlagRequired("version"))
 
 	return cmd
 }

--- a/cmd/pulumictl/download-binary/cli.go
+++ b/cmd/pulumictl/download-binary/cli.go
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package download_binary
+package download_binary //nolint:revive // backwards compatibility
 
 import (
 	"archive/tar"
@@ -83,7 +83,7 @@ func Command() *cobra.Command {
 }
 
 func downloadBinary(url, destFile string) error {
-	response, err := http.Get(url)
+	response, err := http.Get(url) //nolint:gosec
 	if err != nil {
 		return err
 	}
@@ -130,7 +130,7 @@ func decompressBinary(srcFile, cwd string) error {
 		} else if err != nil {
 			return err
 		}
-		path := filepath.Join(fmt.Sprintf("%s/bin", cwd), header.Name)
+		path := filepath.Join(cwd, "bin", header.Name) //nolint:gosec
 		info := header.FileInfo()
 		if info.IsDir() {
 			if err = os.MkdirAll(path, info.Mode()); err != nil {
@@ -143,7 +143,7 @@ func decompressBinary(srcFile, cwd string) error {
 		if err != nil {
 			return err
 		}
-		_, err = io.Copy(file, tarReader)
+		_, err = io.Copy(file, tarReader) //nolint:gosec
 		if err != nil {
 			file.Close()
 			return err

--- a/cmd/pulumictl/download-binary/cli.go
+++ b/cmd/pulumictl/download-binary/cli.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumictl/pkg/util"
 	"github.com/spf13/cobra"
 )
 
@@ -74,9 +75,9 @@ func Command() *cobra.Command {
 		"host", "https://github.com", "The host of the repo to download from. "+
 			"Defaults to https://github.com")
 
-	cmd.MarkFlagRequired("repo-slug")
-	cmd.MarkFlagRequired("name")
-	cmd.MarkFlagRequired("version")
+	util.NoErr(cmd.MarkFlagRequired("repo-slug"))
+	util.NoErr(cmd.MarkFlagRequired("name"))
+	util.NoErr(cmd.MarkFlagRequired("version"))
 
 	return cmd
 }

--- a/cmd/pulumictl/download-binary/cli.go
+++ b/cmd/pulumictl/download-binary/cli.go
@@ -43,7 +43,7 @@ func Command() *cobra.Command {
 			"\nThis will download a version of binary to a specific location.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			filename := fmt.Sprintf("%s-%s-%s-%s.tar.gz", name, version, runtime.GOOS, runtime.GOARCH)
-			downloadUrl := fmt.Sprintf("%s/%s/releases/download/%s/%s", host, repoSlug, version, filename)
+			downloadURL := fmt.Sprintf("%s/%s/releases/download/%s/%s", host, repoSlug, version, filename)
 
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -51,7 +51,7 @@ func Command() *cobra.Command {
 			}
 			srcFile := fmt.Sprintf("%s/bin/%s", cwd, filename)
 
-			err = downloadBinary(downloadUrl, srcFile)
+			err = downloadBinary(downloadURL, srcFile)
 			if err != nil {
 				return err
 			}

--- a/cmd/pulumictl/generate/cli.go
+++ b/cmd/pulumictl/generate/cli.go
@@ -162,7 +162,7 @@ func writePackage(dir string, pkg map[string][]byte) error {
 		if err != nil && !os.IsExist(err) {
 			return err
 		}
-		err = ioutil.WriteFile(fullPath, source, 0644)
+		err = ioutil.WriteFile(fullPath, source, 0644) //nolint:gosec
 		if err != nil {
 			return err
 		}

--- a/cmd/pulumictl/get/latest_plugin/cli.go
+++ b/cmd/pulumictl/get/latest_plugin/cli.go
@@ -36,7 +36,7 @@ func Command() *cobra.Command {
 
 			tags, _, err := client.Repositories.ListTags(ctx, org, project, nil)
 			if err != nil {
-				return fmt.Errorf("unable to list tags from GitHub: %w\n", err)
+				return fmt.Errorf("unable to list tags from GitHub: %w", err)
 			}
 
 			for t := 0; t < numOfTagsToCheck; t++ {
@@ -45,7 +45,7 @@ func Command() *cobra.Command {
 
 			result, err := pluginversion.CheckPluginTags(project, tagsToCheck)
 			if err != nil {
-				return fmt.Errorf("unable to get plugin tags: %w\n", err)
+				return fmt.Errorf("unable to get plugin tags: %w", err)
 			}
 
 			fmt.Println(strings.TrimPrefix(result, "v"))

--- a/cmd/pulumictl/get/latest_plugin/cli.go
+++ b/cmd/pulumictl/get/latest_plugin/cli.go
@@ -1,4 +1,4 @@
-package latest_plugin
+package latest_plugin //nolint:revive // backwards compatibility
 
 import (
 	"fmt"

--- a/cmd/pulumictl/get/version/cli.go
+++ b/cmd/pulumictl/get/version/cli.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/pulumi/pulumictl/pkg/gitversion"
+	"github.com/pulumi/pulumictl/pkg/util"
 	"github.com/spf13/cobra"
 	viperlib "github.com/spf13/viper"
 )
@@ -104,23 +105,25 @@ func Command() *cobra.Command {
 
 	command.Flags().StringP("repo", "r", "", "path to repository, defaults to current working directory")
 	command.Flags().StringVarP(&language, "language", "p", "", "the platform for which the version should be output.")
-	command.Flags().StringVar(&versionPrefix, "version-prefix", "", "the version prefix (e.g. 3.0.0). Must be valid semver.")
-	command.Flags().BoolVarP(&omitCommitHash, "omit-commit-hash", "o", false, "whether to include or omit the commit hash in the version")
+	command.Flags().StringVar(&versionPrefix,
+		"version-prefix", "", "the version prefix (e.g. 3.0.0). Must be valid semver.")
+	command.Flags().BoolVarP(&omitCommitHash,
+		"omit-commit-hash", "o", false, "whether to include or omit the commit hash in the version")
 	command.Flags().BoolVar(&isPreRelease, "is-prerelease", false, "whether this is a pre-release version")
 	command.Flags().StringVar(&tagPattern, "tag-pattern", "", "regex pattern to filter tags with (e.g. ^sdk/)")
 
 	viper.SetDefault("language", "generic")
-	viper.BindEnv("language", "PULUMI_LANGUAGE")
-	viper.BindPFlag("language", command.Flags().Lookup("language"))
+	util.NoErr(viper.BindEnv("language", "PULUMI_LANGUAGE"))
+	util.NoErr(viper.BindPFlag("language", command.Flags().Lookup("language")))
 
-	viper.BindEnv("version-prefix", "VERSION_PREFIX")
-	viper.BindPFlag("version-prefix", command.Flags().Lookup("version-prefix"))
+	util.NoErr(viper.BindEnv("version-prefix", "VERSION_PREFIX"))
+	util.NoErr(viper.BindPFlag("version-prefix", command.Flags().Lookup("version-prefix")))
 
-	viper.BindEnv("is-prerelease", "IS_PRERELEASE")
-	viper.BindPFlag("is-prerelease", command.Flags().Lookup("is-prerelease"))
+	util.NoErr(viper.BindEnv("is-prerelease", "IS_PRERELEASE"))
+	util.NoErr(viper.BindPFlag("is-prerelease", command.Flags().Lookup("is-prerelease")))
 
-	viper.BindEnv("tag-pattern", "TAG_PATTERN")
-	viper.BindPFlag("tag-pattern", command.Flags().Lookup("tag-pattern"))
+	util.NoErr(viper.BindEnv("tag-pattern", "TAG_PATTERN"))
+	util.NoErr(viper.BindPFlag("tag-pattern", command.Flags().Lookup("tag-pattern")))
 
 	return command
 }

--- a/cmd/pulumictl/main.go
+++ b/cmd/pulumictl/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pulumi/pulumictl/cmd/pulumictl/get"
 	"github.com/pulumi/pulumictl/cmd/pulumictl/version"
 	"github.com/pulumi/pulumictl/pkg/contract"
+	"github.com/pulumi/pulumictl/pkg/util"
 )
 
 var (
@@ -49,9 +50,9 @@ func configureCLI() *cobra.Command {
 	rootCommand.PersistentFlags().StringVarP(&githubToken,
 		"token", "t", "", "a github token to use for making API calls to GitHub.")
 	rootCommand.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "enable debug logging")
-	viper.BindEnv("debug", "PULUMICTL_DEBUG")
-	viper.BindEnv("token", "GITHUB_TOKEN")
-	viper.BindPFlag("debug", rootCommand.PersistentFlags().Lookup("debug"))
+	util.NoErr(viper.BindEnv("debug", "PULUMICTL_DEBUG"))
+	util.NoErr(viper.BindEnv("token", "GITHUB_TOKEN"))
+	util.NoErr(viper.BindPFlag("debug", rootCommand.PersistentFlags().Lookup("debug")))
 
 	return rootCommand
 }

--- a/cmd/pulumictl/main.go
+++ b/cmd/pulumictl/main.go
@@ -46,7 +46,8 @@ func configureCLI() *cobra.Command {
 	rootCommand.AddCommand(download_binary.Command())
 	rootCommand.AddCommand(convert_version.Command())
 
-	rootCommand.PersistentFlags().StringVarP(&githubToken, "token", "t", "", "a github token to use for making API calls to GitHub.")
+	rootCommand.PersistentFlags().StringVarP(&githubToken,
+		"token", "t", "", "a github token to use for making API calls to GitHub.")
 	rootCommand.PersistentFlags().BoolVarP(&debug, "debug", "D", false, "enable debug logging")
 	viper.BindEnv("debug", "PULUMICTL_DEBUG")
 	viper.BindEnv("token", "GITHUB_TOKEN")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pulumi/pulumictl
 
-go 1.18
+go 1.21
 
 replace github.com/fsnotify/fsnotify v1.6.0 => ./fsnotify
 

--- a/go.sum
+++ b/go.sum
@@ -560,6 +560,7 @@ github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfn
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.4/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8 h1:AkaSdXYQOWeaO3neb8EM634ahkXXe3jYbVh/F9lq+GI=
+github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
@@ -1336,6 +1337,7 @@ lukechampine.com/frand v1.4.2/go.mod h1:4S/TM2ZgrKejMcKMbeLjISpJMO+/eZ1zu3vYX9dt
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 pgregory.net/rapid v0.4.7 h1:MTNRktPuv5FNqOO151TM9mDTa+XHcX6ypYeISDVD14g=
+pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/pdf v0.1.1/go.mod h1:n8OzWcQ6Sp37PL01nO98y4iUCRdTGarVfzxY20ICaU4=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,7 @@
+package util
+
+func NoErr(err error) {
+	if err != nil {
+		panic("internal error: " + err.Error())
+	}
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,7 +1,13 @@
 package util
 
+// Assert that an error will be nil.
 func NoErr(err error) {
 	if err != nil {
 		panic("internal error: " + err.Error())
 	}
 }
+
+// Ignore a value.
+//
+// Useful for declaring that an error is irrelevant.
+func Ignore[T any](T) {}


### PR DESCRIPTION
Fixes #70

This PR:
1. Moves us from go1.18 to go1.21.
2. Updates the linters we are using.
3. Resolves lint errors
4. Adds a CI step to enforce the linter.