### PR TITLE
fix go install command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build: bin
 	go build -C cmd/pulumictl -o ${ROOT_DIR}/bin
 
 install:
-	go -C cmd/pulumictl install
+	go install -C cmd/pulumictl
 
 clean:
 	rm -rf bin


### PR DESCRIPTION
The go command itself doesn't take a -C argument, but the go install command does.  Fix that, so `make install` works.