### PR TITLE
allow sending key/value pairs with dispatch

### DIFF
--- a/cmd/pulumictl/dispatch/cli.go
+++ b/cmd/pulumictl/dispatch/cli.go
@@ -31,18 +31,29 @@ func Command() *cobra.Command {
 	viper := viperlib.New()
 
 	command := &cobra.Command{
-		Use:   "dispatch [ref]",
+		Use:   "dispatch <ref> | <key>=<value>...",
 		Short: "Send a command dispatch event with a ref",
 		Long:  `Send a repository dispatch payload to a given repo`,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			// Grab all the configuration variables
 			githubToken := viperlib.GetString("token")
 			org = viper.GetString("org")
 			repo := viper.GetString("repo")
 			command := viper.GetString("command")
-			ref := args[0]
+
+			payloadMap := make(map[string]string)
+			if len(args) == 1 && !strings.Contains(args[0], "=") {
+				payloadMap["ref"] = args[0]
+			} else {
+				for _, arg := range args {
+					parts := strings.SplitN(arg, "=", 2)
+					if len(parts) != 2 {
+						return fmt.Errorf("invalid argument: %s", arg)
+					}
+					payloadMap[parts[0]] = parts[1]
+				}
+			}
 
 			// perform some string manipulation and validation
 			repoArray := strings.Split(repo, "/")
@@ -53,7 +64,6 @@ func Command() *cobra.Command {
 			}
 
 			_, err := semver.Parse(gitversion.StripModuleTagPrefixes(ref))
-
 			if err != nil {
 				return fmt.Errorf("must specify a valid semver ref - value: %s", ref)
 			}
@@ -62,10 +72,7 @@ func Command() *cobra.Command {
 			ctx, client := gh.CreateGithubClient(githubToken)
 
 			// create the JSON payload
-			jsonPayload, err := json.Marshal(Payload{
-				Ref: ref,
-			})
-
+			jsonPayload, err := json.Marshal(payloadMap)
 			if err != nil {
 				return err
 			}
@@ -89,7 +96,6 @@ func Command() *cobra.Command {
 			fmt.Println(string(payload))
 
 			return nil
-
 		},
 	}
 


### PR DESCRIPTION
Make pulumictl dispatch more generally useful, and allow key/value pairs in addition to a single ref.  For starters we'll use this to dispatch a GitHub actions job that will update the `latest-dev-version` file (see https://github.com/pulumi/docs/pull/10365), but this can be used for other workflows as well.

/xref https://github.com/pulumi/pulumi/issues/14623