### PR TITLE
use PULUMI_BOT_TOKEN for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           version: latest
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
       - name: Chocolatey Package Deployment
         run: |
           make install


### PR DESCRIPTION
The BOT_GITHUB_TOKEN seems to be a classic PAT, which we no longer allow to access repos in the pulumi org.  Switch this to the PULUMI_BOT_TOKEN, which I *think* is a valid fine-grained PAT.

I believe this should fix the problems encountered in https://github.com/pulumi/pulumictl/actions/runs/7194011043/job/19593606516, but I don't have any access to the tokens, so I can't verify without just trying it.

/cc @blampe who did the switch over for PATs.