### PR TITLE
Use ESC secrets

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,12 +1,22 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: prerelease
 on:
   push:
-    tags: [ "*.*.*-**" ] # Glob pattern matching valid prelease semver
+    tags: ["*.*.*-**"]
 
-jobs:    
+jobs:
   goreleaser:
     runs-on: macos-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout
         uses: actions/checkout@v4
       - name: Unshallow clone
@@ -21,4 +31,4 @@ jobs:
           version: v1.26.2
           args: release --rm-dist --config=.goreleaser.prelease.yml
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.BOT_GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,22 @@
+permissions: write-all # Equivalent to default permissions plus id-token: write
+env:
+  ESC_ACTION_OIDC_AUTH: true
+  ESC_ACTION_OIDC_ORGANIZATION: pulumi
+  ESC_ACTION_OIDC_REQUESTED_TOKEN_TYPE: urn:pulumi:token-type:access_token:organization
+  ESC_ACTION_ENVIRONMENT: imports/github-secrets
+  ESC_ACTION_EXPORT_ENVIRONMENT_VARIABLES: false
 name: release
 on:
   push:
-    tags: [ "v*.*.*" ] # only a valid semver tag
+    tags: ["v*.*.*"]
 
 jobs:
   goreleaser:
     runs-on: macos-latest
     steps:
+      - name: Fetch secrets from ESC
+        id: esc-secrets
+        uses: pulumi/esc-action@v1
       - name: Checkout
         uses: actions/checkout@v4
       - name: Unshallow clone
@@ -21,11 +31,11 @@ jobs:
           version: v1.26.2
           args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN }}
       - name: Chocolatey Package Deployment
         run: |
           make install
           CURRENT_TAG=$(pulumictl get version --language generic -o)
           pulumictl create choco-deploy -a pulumictl ${CURRENT_TAG}
         env:
-          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.esc-secrets.outputs.PULUMI_BOT_TOKEN}}


### PR DESCRIPTION
These changes migrate this repo's GitHub Actions Workflows to use ESC secrets instead of GitHub Secrets.

The changes are largely mechanical:

- Common configuration for all ESC actions within a workflow is added to the workflow's environment variables
- Permissions are expanded as necessary for workflows that do not grant `id-token: write` permissions
	- `read-all` permissions are replaced with the union of all explicit read permissions and `id-token: write`
	- Default permissions are replaced with `write-all`, which is the equivalent of all explicit write permissions and
	  `id-token: write`
	- Explicit permissions are modified to grant `id-token: write`
- A step that fetches ESC secrets and populates environment variables is added to each step that reads secrets
- Direct references to secrets within the job are replaced with references to the step's outputs

All ESC actions are configured to fetch secrets from a shared ESC environment that contains secrets migrated from GitHub Actions. The ESC action performs its own OIDC exchange to obtain a Pulumi Access Token.
